### PR TITLE
Support workflow lifecycle, workflow flow patterns: orchestration and graph image generation styled

### DIFF
--- a/jai-workflow-core/pom.xml
+++ b/jai-workflow-core/pom.xml
@@ -26,6 +26,11 @@
         </dependency>
 
         <dependency>
+            <groupId>guru.nidi</groupId>
+            <artifactId>graphviz-rough</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.graalvm.js</groupId>
             <artifactId>js</artifactId>
             <scope>runtime</scope>

--- a/jai-workflow-core/pom.xml
+++ b/jai-workflow-core/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.github.czelabueno</groupId>
         <artifactId>jai-workflow-parent</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/jai-workflow-core/src/main/java/io/github/czelabueno/jai/workflow/DefaultStateWorkflow.java
+++ b/jai-workflow-core/src/main/java/io/github/czelabueno/jai/workflow/DefaultStateWorkflow.java
@@ -1,61 +1,193 @@
 package io.github.czelabueno.jai.workflow;
 
+import io.github.czelabueno.jai.workflow.graph.Format;
+import io.github.czelabueno.jai.workflow.graph.StyleAttribute;
 import io.github.czelabueno.jai.workflow.node.Conditional;
 import io.github.czelabueno.jai.workflow.node.Node;
+import io.github.czelabueno.jai.workflow.transition.ComputedTransition;
 import io.github.czelabueno.jai.workflow.transition.Transition;
 import io.github.czelabueno.jai.workflow.graph.GraphImageGenerator;
 import io.github.czelabueno.jai.workflow.graph.graphviz.GraphvizImageGenerator;
 import io.github.czelabueno.jai.workflow.transition.TransitionState;
-import lombok.Builder;
-import lombok.NonNull;
-import lombok.Singular;
+import lombok.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.LinkedBlockingQueue;
 import java.util.function.Consumer;
+
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toUnmodifiableList;
 
 public class DefaultStateWorkflow<T> implements StateWorkflow<T> {
 
     private static final Logger log = LoggerFactory.getLogger(DefaultStateWorkflow.class);
-    private final Map<Node<T,?>, List<TransitionState>> adjList;
+    private final Map<TransitionState, List<TransitionState>> adjList;
     private volatile Node<T,?> startNode;
     private final T statefulBean;
-    private final List<Transition> transitions;
-    private GraphImageGenerator graphImageGenerator;
+    private final List<Transition> transitions; // definition transitions
+    private final Map<TransitionState, CounterTransitionsPerState> transitionsPerState;
+    private final List<TransitionState> compiledStates;
+    private int executionOrder;
+    private final List<ComputedTransition> computedTransitions; // computed transitions after running
+    private final GraphImageGenerator graphImageGenerator;
 
-    @Builder
-    public DefaultStateWorkflow(@NonNull T statefulBean,
-                                @Singular List<Node<T,?>> addNodes,
-                                GraphImageGenerator graphImageGenerator) {
-        if (addNodes.isEmpty()) {
-            throw new IllegalArgumentException("At least one node must be added to the workflow");
+    protected DefaultStateWorkflow(Builder<T> builder) {
+        if (builder.statefulBean == null) {
+            throw new IllegalArgumentException("Stateful bean cannot be null");
+        }
+        if (builder.addEdges == null || builder.addEdges.isEmpty()) {
+            throw new IllegalArgumentException("At least one edged must be added to the workflow");
         }
 
-        this.statefulBean = statefulBean;
+        this.statefulBean = builder.statefulBean;
         this.adjList = new ConcurrentHashMap<>();
         this.transitions = Collections.synchronizedList(new ArrayList<>());
+        this.computedTransitions = Collections.synchronizedList(new ArrayList<>());
 
-        if (graphImageGenerator != null) {
-            this.graphImageGenerator = graphImageGenerator;
-        } else {
-            this.graphImageGenerator = GraphvizImageGenerator.<T>builder().build();
-        }
+        this.graphImageGenerator = builder.graphImageGenerator != null ? builder.graphImageGenerator : GraphvizImageGenerator.builder().build();
 
-        // Add nodes to adjList if they are not already present
-        for (Node<T,?> node : addNodes) {
-            this.adjList.putIfAbsent(node, Collections.synchronizedList(new ArrayList<>()));
-        }
+        // build transitions definition
+        this.transitionsPerState = new ConcurrentHashMap<>();
+        buildDefinitionTransitions(builder.addEdges, builder.addNodes);
+
+        // build validation
+        this.compiledStates = Collections.synchronizedList(new ArrayList<>());
+        compileValidation(WorkflowStateName.START);
     }
 
-    public void setGraphImageGenerator(GraphImageGenerator graphImageGenerator) {
-        this.graphImageGenerator = graphImageGenerator;
+    private void buildDefinitionTransitions(List<Transition> edges, List<Node<T, ?>> nodes) {
+        // Add edges to adjList
+        this.adjList.clear();
+        edges.forEach(transition -> {
+            this.adjList.putIfAbsent(transition.from(), Collections.synchronizedList(new ArrayList<>()));
+            this.adjList.putIfAbsent(transition.to(), Collections.synchronizedList(new ArrayList<>()));
+            if (transition.from() instanceof Conditional conditionalFrom) { // Add expected nodes to adjList if the 'from' node is a Conditional
+                this.adjList.get(conditionalFrom).addAll(conditionalFrom.getExpectedNodes());
+            } else if (transition.to() instanceof Conditional conditionalTo) { // Add expected nodes to adjList if the 'to' node is a Conditional
+                this.adjList.get(conditionalTo).addAll(conditionalTo.getExpectedNodes());
+                this.adjList.get(transition.from()).add(conditionalTo); // Add the Conditional node to the adjList
+            } else {
+                this.adjList.get(transition.from()).add(transition.to()); // Add the edge to the adjList
+            }
+        });
+
+        // Add nodes to adjList if they are not already present
+        nodes.forEach(node -> this.adjList.putIfAbsent(node, Collections.synchronizedList(new ArrayList<>())));
+
+        // Count the number of input and output transitions for each state
+        this.transitionsPerState.clear();
+        this.adjList.forEach((node, transitionStates) -> {
+            transitionStates.forEach(transition -> this.transitionsPerState
+                    .computeIfAbsent(transition, k -> new CounterTransitionsPerState(0, 0))
+                    .incrementInputTransitions()); // the existing or new CounterTransitionsPerState is updated with the incremented input transitions
+            this.transitionsPerState.computeIfAbsent(node, k -> new CounterTransitionsPerState(0, transitionStates.size()))
+                    .setOutputTransitions(transitionStates.size());
+        });
+
+
+        if (!this.transitionsPerState.containsKey(WorkflowStateName.START)) {
+            // Setting nodes without incoming transitions as first nodes
+            List<TransitionState> firstStates = this.transitionsPerState.entrySet().stream()
+                    .filter(counter -> counter.getValue().getInputTransitions() == 0)
+                    .map(Map.Entry::getKey)
+                    .collect(toList());
+
+            this.adjList.putIfAbsent(WorkflowStateName.START, firstStates);
+            this.transitionsPerState.putIfAbsent(WorkflowStateName.START, new CounterTransitionsPerState(0, firstStates.size()));
+            firstStates.stream().forEach(firstState -> transitionsPerState.get(firstState).incrementInputTransitions());
+
+        }
+        if (!this.transitionsPerState.containsKey(WorkflowStateName.END)) {
+            // Setting nodes without outgoing transitions as last nodes
+            List<TransitionState> lastStates = this.transitionsPerState.entrySet().stream()
+                    .filter(counter -> counter.getValue().getOutputTransitions() == 0)
+                    .map(Map.Entry::getKey)
+                    .collect(toList());
+
+            lastStates.stream().forEach(lastState -> this.adjList.computeIfAbsent(lastState, k -> Collections.synchronizedList(new ArrayList<>())).add(WorkflowStateName.END));
+            this.transitionsPerState.putIfAbsent(WorkflowStateName.END, new CounterTransitionsPerState(lastStates.size(), 0));
+            lastStates.stream().forEach(lastState -> this.transitionsPerState.get(lastState).incrementOutputTransitions());
+        }
+        // Add all built transitions from adjList
+        this.transitions.clear();
+        this.adjList.forEach((node, ts) -> ts.forEach(transitionStateTo -> this.transitions.add(Transition.from(node, transitionStateTo))));
+    }
+
+    private void compileValidation(TransitionState state) {
+        boolean isSplit = false;
+        if (this.transitionsPerState.get(state).getOutputTransitions() > 1 && !(state instanceof Conditional)) {
+            isSplit = true;
+        };
+        boolean isMerge = false;
+        boolean isParallel = false;
+
+        if (state instanceof Node) {
+            Node node = (Node) state;
+            isMerge = node.hasLabel("Merge");
+            isParallel = node.hasLabel("Parallel");
+            if (isParallel && isSplit) {
+                throw new IllegalArgumentException("A parallel node '" + node.graphName() + "' cannot be a split node in the same flow");
+            }
+            if (isMerge && isSplit) {
+                throw new IllegalArgumentException("A merge node '" + node.graphName() + "' cannot be a split node in the same flow");
+            }
+            if (isMerge && isParallel) {
+                throw new IllegalArgumentException("A merge node '" + node.graphName() + "' cannot be a parallel node in the same flow");
+            }
+            if (isMerge) {
+                int mergeInputTransitions = this.transitionsPerState.get(state).getInputTransitions(); // number of input transitions for merge node
+                this.compiledStates.stream()
+                        .filter(compiledState -> compiledState.hasLabel("Split"))
+                        .findAny()
+                        .ifPresent(existingSplitNode -> {
+                            int splitOutputTransitions = this.transitionsPerState.get(existingSplitNode).getOutputTransitions(); // number of output transitions for split node
+                            if (mergeInputTransitions != splitOutputTransitions) {
+                                throw new IllegalArgumentException("The merge node '" + node.graphName() + "' must have the same number of input transitions as the number of output transitions from the split node '" + existingSplitNode.graphName() + "'");
+                            }
+                        });
+            }
+            if (isSplit) node.setLabels("Split");
+        }
+        this.compiledStates.add(state); // state compiled and validated
+
+        List<TransitionState> nextStates = this.adjList.get(state);
+        for (TransitionState nextState : nextStates) {
+            if (!this.compiledStates.contains(nextState)) {
+                if (nextState instanceof Node) {
+                    Node<T, ?> targetNode = (Node<T, ?>) nextState;
+                    if (isSplit || isParallel) {
+                        targetNode.setLabels("Parallel");
+                    }
+                    if (this.transitionsPerState.get(targetNode).getInputTransitions() > 1 && this.transitions.stream()
+                                .filter(transition -> transition.to().equals(targetNode) && transition.from() instanceof Conditional)
+                                .findAny()
+                                .isEmpty()){ // 'from' should not be a Conditional node
+                        targetNode.labels().clear();
+                        targetNode.setLabels("Merge");
+                    }
+                }
+                if (isParallel){
+                    if (nextState instanceof WorkflowStateName) {
+                        throw new IllegalArgumentException("The state " + state.graphName() + " labeled as 'Parallel' cannot have a WorkflowStateName '" + nextState.graphName() +"' as an adjacent node");
+                    } else if (!nextState.hasLabel("Merge") && !nextState.hasLabel("Parallel")) {
+                        throw new IllegalArgumentException("A node labeled as 'Parallel' must have a node labeled as 'Merge' or 'Parallel' as an adjacent node");
+                    }
+                }
+                if (nextState == WorkflowStateName.END) {
+                    return;
+                }
+                compileValidation(nextState);
+            }
+        }
+        // Constraint 7
+        // This constraint requires runtime behavior, so it should be implemented in the `runNode` method.
     }
 
     @Override
@@ -65,160 +197,295 @@ public class DefaultStateWorkflow<T> implements StateWorkflow<T> {
 
     @Override
     public void putEdge(Node<T, ?> from, Node<T, ?> to) {
-        adjList.get(from).add(to);
+        putEdgeIfAbsent(from, to);
     }
 
     @Override
     public void putEdge(Node<T, ?> from, Conditional<T> conditional) {
-        adjList.get(from).add(conditional);
+        putEdgeIfAbsent(from, conditional);
     }
 
     @Override
     public void putEdge(Node<T, ?> from, WorkflowStateName state) {
-        adjList.get(from).add(state);
+        putEdgeIfAbsent(from, state);
+    }
+
+    private void putEdgeIfAbsent(TransitionState from, TransitionState to) {
+        // if the edge is already present, skip
+        if (this.transitions.stream().noneMatch(transition -> transition.from().equals(from) && transition.to().equals(to))) {
+            // 1. If the incoming 'from' transitionState already has an END state set, it will be removed to replace the new 'to' transitionState.
+            this.transitions.removeIf(transition -> transition.from().equals(from) && transition.to() == WorkflowStateName.END);
+            // 2. If the incoming 'to' transitionState is an explicit END state, the existing transition with END state will be removed and the incoming 'from' transitionState will be updated.
+            if (to == WorkflowStateName.END) {
+                this.transitions.removeIf(transition -> transition.to() == to);
+                this.transitions.removeIf(transition -> transition.from().equals(from));
+            }
+            this.transitions.add(Transition.from(from, to));
+            buildDefinitionTransitions(this.transitions, List.of()); // rebuild transitions, no nodes to add
+            this.compiledStates.clear();
+            compileValidation(WorkflowStateName.START); // recompile validation
+        }
     }
 
     @Override
-    public void startNode(Node<T,?> startNode){
+    public DefaultStateWorkflow startNode(Node<T,?> startNode){
         this.startNode = startNode;
+        return this;
     }
 
     @Override
     public Node<T, ?> getLastNode() {
-        if (adjList.isEmpty() || adjList == null)
+        if (this.adjList.isEmpty() || this.adjList == null)
             throw new IllegalStateException("No nodes added to the workflow");
 
-        return adjList.entrySet()
-                .stream()
+        return this.adjList.entrySet().stream()
                 .filter(entry -> entry.getValue().contains(WorkflowStateName.END))
-                .<Node<T, ?>>map(Map.Entry::getKey)
-                .findFirst()
-                .orElseGet(() -> adjList.keySet()
-                        .<Node<T, ?>>stream()
-                        .reduce((first, second) -> second)
-                        .orElseThrow());
+                .map(Map.Entry::getKey)
+                .filter(Node.class::isInstance)
+                .<Node<T, ?>>map(node -> (Node<T, ?>) node)
+                .reduce((first, second) -> second)
+                .orElseGet(() -> this.transitionsPerState.entrySet().stream()
+                                .filter(counter -> counter.getValue().getOutputTransitions() == 0)
+                                .map(Map.Entry::getKey)
+                                .filter(Node.class::isInstance)
+                                .reduce((first, second) -> second)
+                                .map(node -> (Node<T, ?>) node)
+                                .orElseThrow(() -> new IllegalStateException("No nodes added to the workflow")));
     }
 
     @Override
     public T run() {
-        transitions.clear(); // clean previous transitions
-        log.debug("STARTING workflow in normal mode..");
-        runNode(startNode);
-        return statefulBean;
-    }
-
-    private void runNode(Node<T,?> node) {
-        if (node == null) return;
-        log.debug("Running node name: " + node.getName() + "..");
-        if (node == startNode)
-            transitions.add(Transition.from(WorkflowStateName.START, node));
-        synchronized (statefulBean){
-            node.execute(statefulBean);
-        }
-        List<TransitionState> nextNodes;
-        synchronized (adjList) {
-            nextNodes = adjList.get(node);
-        }
-        for (TransitionState nextNode : nextNodes) {
-            if (nextNode instanceof WorkflowStateName) {
-                WorkflowStateName next = (WorkflowStateName) nextNode;
-                if (next == WorkflowStateName.END) {
-                    log.debug("Reached END state");
-                    transitions.add(Transition.from(node, WorkflowStateName.END));
-                    return;
-                }
-                transitions.add(Transition.from(node, next));
-            } else if (nextNode instanceof Node) {
-                Node<T,?> next = (Node<T,?>) nextNode;
-                transitions.add(Transition.from(node, next));
-                runNode(next);
-            } else if (nextNode instanceof Conditional) {
-                Node<T,?> conditionalNode = ((Conditional<T>) nextNode).evaluate(statefulBean);
-                transitions.add(Transition.from(node, conditionalNode));
-                runNode(conditionalNode);
-            }
-        }
+        return run(this.startNode, null);
     }
 
     @Override
     public T runStream(Consumer<Node<T, ?>> eventConsumer) {
-        transitions.clear(); // clean previous transitions
-        log.debug("STARTING workflow in stream mode..");
-        Queue<TransitionState> queue = new LinkedBlockingQueue<>();
-        queue.add(startNode);
-        transitions.add(Transition.from(WorkflowStateName.START, startNode));
-        while (!queue.isEmpty()) {
-            TransitionState current = queue.poll();
-            if (current instanceof Node) {
-                Node<T,?> currentNode = (Node<T,?>) current;
-                //eventConsumer.accept(currentNode);
-                synchronized (statefulBean){
-                    currentNode.execute(statefulBean);
-                }
-                eventConsumer.accept(currentNode);
-                List<TransitionState> nextNodes;
-                synchronized (adjList) {
-                    nextNodes = adjList.get(currentNode);
-                }
-                if (nextNodes != null) {
-                    for (TransitionState next : nextNodes) {
-                        if (next instanceof WorkflowStateName) {
-                            WorkflowStateName nextState = (WorkflowStateName) next;
-                            if (nextState == WorkflowStateName.END) {
-                                transitions.add(Transition.from(currentNode, WorkflowStateName.END));
-                                return statefulBean;
-                            }
-                            transitions.add(Transition.from(currentNode, next));
-                            queue.add(next);
-                        } else if (next instanceof Node) {
-                            transitions.add(Transition.from(currentNode, next));
-                            queue.add(next);
-                        } else if (next instanceof Conditional) {
-                            Node<T,?> conditionalNode = ((Conditional<T>) next).evaluate(statefulBean);
-                            transitions.add(Transition.from(currentNode, conditionalNode));
-                            queue.add(conditionalNode);
-                        }
-                    }
-                }
-            } else if (current == WorkflowStateName.END) {
-                log.debug("Reached END state");
-                return statefulBean;
-            }
+        return run(this.startNode, eventConsumer);
+    }
+
+    private T run(Node<T,?> node, Consumer<Node<T, ?>> eventConsumer) {
+        if (this.compiledStates == null || this.compiledStates.isEmpty()) {
+            throw new IllegalStateException("jai workflow cannot run without a built workflow");
         }
+        if (this.transitions == null || this.transitions.isEmpty()) {
+            throw new IllegalStateException("jai workflow cannot run without edges defined");
+        }
+        List<Node> startNodes = this.adjList.get(WorkflowStateName.START).stream()
+                .filter(transitionState -> transitionState instanceof Node)
+                .map(transitionState -> (Node) transitionState)
+                .toList();
+        node = determineStartNode(node, startNodes);
+
+        resetWorkflowState();
+        log.debug("STARTING workflow{}..", eventConsumer != null ? " in stream mode" : "");
+        runNode(node, eventConsumer);
+        log.debug("END workflow..");
         return statefulBean;
     }
 
+    private Node<T,?> determineStartNode(Node<T,?> node, List<Node> startNodes) {
+        if (node == null) {
+            if (startNodes.size() > 1) {
+                throw new IllegalStateException("Its not possible to determine the start node, multiple start nodes found: " +
+                        startNodes.stream().sorted(Comparator.comparing(startNodes::indexOf)).map(Node::getName).toList() +
+                        "\nPlease specify the start node using the .startNode(Node<T> node) method");
+            } else if (startNodes.size() == 1) {
+                node = startNodes.get(0);
+            }
+        }
+        return node;
+    }
+
+    private void resetWorkflowState() {
+        this.computedTransitions.clear(); // clean previous transitions
+        this.executionOrder=1;
+    }
+
+    private void runNode(Node<T,?> node, Consumer<Node<T, ?>> eventConsumer) {
+        log.debug("Running node name: " + node.getName() + "..");
+        synchronized (this.statefulBean){
+            node.execute(this.statefulBean);
+        }
+        if (eventConsumer != null) {
+            eventConsumer.accept(node);
+        }
+        List<TransitionState> nextNodes;
+        synchronized (this.adjList) {
+            nextNodes = this.adjList.get(node);
+        }
+        for (TransitionState nextNode : nextNodes) {
+            if (nextNode instanceof WorkflowStateName next) {
+                if (next == WorkflowStateName.END) {
+                    log.debug("Reached END state");
+                    computeTransition(this.executionOrder, node, next);
+                    this.executionOrder++;
+                    return;
+                }
+            } else if (nextNode instanceof Node next) {
+                computeTransition(this.executionOrder,node, next);
+                this.executionOrder++;
+                runNode(next, eventConsumer);
+            } else if (nextNode instanceof Conditional next) {
+                computeTransition(this.executionOrder, node, next);
+                this.executionOrder++;
+                Node<T,?> conditionalNode = next.evaluate(this.statefulBean);
+                if (conditionalNode == null) {
+                    throw new IllegalStateException("Conditional node returned null");
+                } else {
+                    computeTransition(this.executionOrder, next, conditionalNode);
+                    this.executionOrder++;
+                    runNode(conditionalNode, eventConsumer);
+                }
+            }
+        }
+    }
+
+    private void computeTransition(Integer order, TransitionState from, TransitionState to) {
+        this.transitions.stream()
+                .filter(transition -> transition.from().equals(from) && transition.to().equals(to))
+                .findAny()
+                .ifPresent(transition -> {
+                    this.computedTransitions.add(ComputedTransition.from(order, transition));
+                });
+    }
+
     @Override
-    public List<Transition> getComputedTransitions() {
-        return new ArrayList<>(transitions);
+    public List<ComputedTransition> getComputedTransitions() {
+        if (!wasRun()) {
+            throw new RuntimeException("Workflow has not been run yet. No transitions computed");
+        }
+        return this.computedTransitions.stream()
+                .sorted(Comparator.comparing(ComputedTransition::getOrder))
+                .collect(toUnmodifiableList());
+    }
+
+    public Boolean wasRun() {
+        return !this.computedTransitions.isEmpty();
+    }
+
+    @Override
+    public void generateComputedWorkflowImage(Format format, String outputPath, List<StyleAttribute> styleAttributes) throws IOException {
+        GraphvizImageGenerator graphImageGenerator = GraphvizImageGenerator.builder()
+                .computedTransitions(getComputedTransitions())
+                .build();
+        imageGenerator(graphImageGenerator, format, outputPath, styleAttributes);
+    }
+
+    @Override
+    public BufferedImage generateComputedWorkflowBufferedImage(Format format, List<StyleAttribute> styleAttributes) throws RuntimeException {
+        GraphvizImageGenerator graphImageGenerator = GraphvizImageGenerator.builder()
+                .computedTransitions(getComputedTransitions())
+                .build();
+        return imageGenerator(graphImageGenerator, format, styleAttributes);
     }
 
     public String prettyTransitions() {
         StringBuilder sb = new StringBuilder();
-        Object lastTo = null;
-        for (Transition transition : transitions) {
-            if (transition.from().equals(lastTo)) {
-                sb.append(" -> ").append(transition.to() instanceof Node ? ((Node) transition.to()).getName() : transition.to().toString());
-            } else {
-                if (sb.length() > 0) sb.append(" ");
-                sb.append(transition.from() instanceof Node ? ((Node)transition.from()).getName() : transition.from().toString()).append(" -> ").append(transition.to() instanceof Node ? ((Node) transition.to()).getName() : transition.to().toString());
-            }
-            lastTo = transition.to() instanceof Node ? (Node) transition.to() : transition.to();
+        for (ComputedTransition transition : getComputedTransitions()) {
+            sb.append("[")
+                    .append(transition.getTransition())
+                    .append(" {")
+                    .append("Order: "+ transition.getOrder()+", ")
+                    .append("ComputedAt: "+ transition.getComputedAt()+", ")
+                    .append("Payload: "+ transition.getPayload() + " }").append("]\n");
         }
         return sb.toString();
     }
 
+    // TODO: add a new parameter to specify the graph style: Layout DOT[normal, Sketchviz], Mermaid, etc
     @Override
-    public void generateWorkflowImage(String outputPath) throws IOException {
+    public void generateWorkflowImage(Format format, String outputPath, List<StyleAttribute> styleAttributes) throws IOException {
+        imageGenerator(this.graphImageGenerator, format, outputPath, styleAttributes);
+    }
+
+    @Override
+    public BufferedImage generateWorkflowBufferedImage(Format format, List<StyleAttribute> styleAttributes) throws RuntimeException {
+        return imageGenerator(this.graphImageGenerator, format, styleAttributes);
+    }
+
+    private BufferedImage imageGenerator(GraphImageGenerator graphImageGenerator, Format format, List<StyleAttribute> styleAttributes) throws RuntimeException {
+        List<Transition> transitions = this.transitions.stream().toList();
+        return graphImageGenerator.generateBufferedImage(
+                transitions,
+                format,
+                styleAttributes.toArray(new StyleAttribute[0]));
+    }
+
+    private void imageGenerator(GraphImageGenerator graphImageGenerator, Format format, String outputPath, List<StyleAttribute> styleAttributes) throws IOException {
+        List<Transition> transitions = this.transitions.stream().toList();
         try {
             Path path = Paths.get(outputPath);
-            this.graphImageGenerator.generateImage(this.transitions, path.toAbsolutePath().toString()); // Absolute path by default
+            graphImageGenerator.generateImage(
+                    transitions,
+                    path.toAbsolutePath().toString(), // Absolute path by default
+                    format,
+                    styleAttributes.toArray(new StyleAttribute[0]));
         } catch (InvalidPathException e) {
             log.warn("Invalid path: " + outputPath + " using default path");
-            this.graphImageGenerator.generateImage(this.transitions);
+            graphImageGenerator.generateImage(transitions, format);
         } catch (IOException e) {
             log.error("Error generating workflow image: " + e.getMessage());
             throw e;
+        }
+    }
+
+    /**
+     * Creates a new builder for the DefaultStateWorkflow class.
+     *
+     * @param <T> the type of the stateful bean
+     * @return a new builder for the DefaultStateWorkflow class
+     */
+    public static <T> Builder<T> builder() {
+        return new Builder<>();
+    }
+
+    public static class Builder<T> {
+        private T statefulBean;
+        private List<Transition> addEdges = new ArrayList<>();
+        private List<Node<T, ?>> addNodes = new ArrayList<>();
+        private GraphImageGenerator graphImageGenerator;
+
+        public Builder<T> statefulBean(T statefulBean) {
+            this.statefulBean = statefulBean;
+            return this;
+        }
+
+        public Builder<T> addEdges(Transition... edges) {
+            this.addEdges.addAll(Arrays.asList(edges));
+            return this;
+        }
+
+        public Builder<T> addNodes(Node<T, ?>... nodes) {
+            this.addNodes.addAll(Arrays.asList(nodes));
+            return this;
+        }
+
+        public Builder<T> graphImageGenerator(GraphImageGenerator graphImageGenerator) {
+            this.graphImageGenerator = graphImageGenerator;
+            return this;
+        }
+
+        public DefaultStateWorkflow<T> build(Node<T,?> startNode) {
+            return this.build().startNode(startNode);
+        }
+
+        public DefaultStateWorkflow<T> build() {
+            return new DefaultStateWorkflow<>(this);
+        }
+    }
+
+    @Data
+    @AllArgsConstructor
+    private static class CounterTransitionsPerState {
+        private int inputTransitions;
+        private int outputTransitions;
+
+        public void incrementInputTransitions() {
+            this.inputTransitions++;
+        }
+
+        public void incrementOutputTransitions() {
+            this.outputTransitions++;
         }
     }
 }

--- a/jai-workflow-core/src/main/java/io/github/czelabueno/jai/workflow/StateWorkflow.java
+++ b/jai-workflow-core/src/main/java/io/github/czelabueno/jai/workflow/StateWorkflow.java
@@ -1,9 +1,12 @@
 package io.github.czelabueno.jai.workflow;
 
+import io.github.czelabueno.jai.workflow.graph.Format;
+import io.github.czelabueno.jai.workflow.graph.StyleAttribute;
 import io.github.czelabueno.jai.workflow.node.Conditional;
 import io.github.czelabueno.jai.workflow.node.Node;
-import io.github.czelabueno.jai.workflow.transition.Transition;
+import io.github.czelabueno.jai.workflow.transition.ComputedTransition;
 
+import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.util.List;
 import java.util.function.Consumer;
@@ -51,7 +54,7 @@ public interface StateWorkflow<T> {
      *
      * @param startNode the starting node
      */
-    void startNode(Node<T,?> startNode);
+    StateWorkflow startNode(Node<T,?> startNode);
 
     /**
      * Returns the last node defined in the workflow.
@@ -80,7 +83,7 @@ public interface StateWorkflow<T> {
      *
      * @return the list of computed transitions
      */
-    List<Transition> getComputedTransitions();
+    List<ComputedTransition> getComputedTransitions();
 
     /**
      * Generates an image of the workflow and saves it to the specified output path.
@@ -88,7 +91,39 @@ public interface StateWorkflow<T> {
      * @param outputPath the path to save the workflow image
      * @throws IOException if an I/O error occurs
      */
-    void generateWorkflowImage(String outputPath) throws IOException;
+    void generateWorkflowImage(Format format, String outputPath, List<StyleAttribute> styleAttributes) throws IOException;
+
+    /**
+     * Generates an image of the workflow and saves it to the specified output path.
+     *
+     * @param outputPath the path to save the workflow image
+     * @param styleAttributes the style attributes to apply to the workflow image
+     * @throws IOException if an I/O error occurs
+     */
+    default void generateWorkflowImage(String outputPath, List<StyleAttribute> styleAttributes) throws IOException {
+        generateWorkflowImage(Format.SVG, outputPath, styleAttributes);
+    }
+
+    /**
+     * Generates an image of the workflow and saves it to the specified output path.
+     *
+     * @param format the format of the image
+     * @param outputPath the path to save the workflow image
+     * @throws IOException if an I/O error occurs
+     */
+    default void generateWorkflowImage(Format format, String outputPath) throws IOException {
+        generateWorkflowImage(format, outputPath, List.of());
+    }
+
+    /**
+     * Generates an image of the workflow and saves it to the specified output path.
+     *
+     * @param outputPath the path to save the workflow image
+     * @throws IOException if an I/O error occurs
+     */
+    default void generateWorkflowImage(String outputPath) throws IOException {
+        generateWorkflowImage(Format.SVG, outputPath);
+    }
 
     /**
      * Generates an image of the workflow and saves it to the default path "workflow-image.svg".
@@ -97,5 +132,140 @@ public interface StateWorkflow<T> {
      */
     default void generateWorkflowImage() throws IOException {
         generateWorkflowImage("workflow-image.svg");
+    }
+
+    /**
+     * Generates a BufferedImage representation of the workflow graph.
+     *
+     * @param format the format of the image
+     * @param styleAttributes the style attributes to apply to the workflow image
+     * @return the BufferedImage representation of the workflow graph
+     * @throws RuntimeException if an error occurs during image generation
+     */
+    BufferedImage generateWorkflowBufferedImage(Format format, List<StyleAttribute> styleAttributes) throws RuntimeException;
+
+    /**
+     * Generates a BufferedImage representation of the workflow graph with Format.SVG. by default.
+     *
+     * @param styleAttributes the style attributes to apply to the workflow image
+     * @return the BufferedImage representation of the workflow graph
+     * @throws RuntimeException if an error occurs during image generation
+     */
+    default BufferedImage generateWorkflowBufferedImage(List<StyleAttribute> styleAttributes) throws RuntimeException {
+        return generateWorkflowBufferedImage(Format.SVG, styleAttributes);
+    }
+
+    /**
+     * Generates a BufferedImage representation of the workflow graph with the specified format.
+     *
+     * @param format the format of the image
+     * @return the BufferedImage representation of the workflow graph
+     * @throws RuntimeException if an error occurs during image generation
+     */
+    default BufferedImage generateWorkflowBufferedImage(Format format) throws RuntimeException {
+        return generateWorkflowBufferedImage(format, List.of());
+    }
+
+    /**
+     * Generates a BufferedImage representation of the workflow graph with Format.SVG. by default.
+     *
+     * @return the BufferedImage representation of the workflow graph
+     * @throws RuntimeException if an error occurs during image generation
+     */
+    default BufferedImage generateWorkflowBufferedImage() throws RuntimeException {
+        return generateWorkflowBufferedImage(Format.SVG);
+    }
+
+    /**
+     * Generates an image of the computed workflow and saves it to the specified output path.
+     *
+     * @param format the format of the image
+     * @param outputPath the path to save the workflow image
+     * @param styleAttributes the style attributes to apply to the workflow image
+     * @throws IOException if an I/O error occurs
+     */
+    void generateComputedWorkflowImage(Format format, String outputPath, List<StyleAttribute> styleAttributes) throws IOException;
+
+    /**
+     * Generates an image of the computed workflow and saves it to the specified output path with Format.SVG by default.
+     *
+     * @param outputPath the path to save the workflow image
+     * @param styleAttributes the style attributes to apply to the workflow image
+     * @throws IOException if an I/O error occurs
+     */
+    default void generateComputedWorkflowImage(String outputPath, List<StyleAttribute> styleAttributes) throws IOException {
+        generateComputedWorkflowImage(Format.SVG, outputPath, styleAttributes);
+    }
+
+    /**
+     * Generates an image of the computed workflow and saves it to the specified output path.
+     *
+     * @param format the format of the image
+     * @param outputPath the path to save the workflow image
+     * @throws IOException if an I/O error occurs
+     */
+    default void generateComputedWorkflowImage(Format format, String outputPath) throws IOException {
+        generateComputedWorkflowImage(format, outputPath, List.of());
+    }
+
+    /**
+     * Generates an image of the computed workflow and saves it to the specified output path with Format.SVG by default.
+     *
+     * @param outputPath the path to save the workflow image
+     * @throws IOException if an I/O error occurs
+     */
+    default void generateComputedWorkflowImage(String outputPath) throws IOException {
+        generateComputedWorkflowImage(Format.SVG, outputPath);
+    }
+
+    /**
+     * Generates an image of the computed workflow and saves it to the default path "computed-workflow-image.svg" in SVG format.
+     *
+     * @throws IOException if an I/O error occurs
+     */
+    default void generateComputedWorkflowImage() throws IOException {
+        generateComputedWorkflowImage("computed-workflow-image.svg");
+    }
+
+    /**
+     * Generates a BufferedImage representation of the computed workflow graph.
+     *
+     * @param format the format of the image
+     * @param styleAttributes the style attributes to apply to the workflow image
+     * @return the BufferedImage representation of the computed workflow graph
+     * @throws IOException if an I/O error occurs
+     */
+    BufferedImage generateComputedWorkflowBufferedImage(Format format, List<StyleAttribute> styleAttributes) throws RuntimeException;
+
+    /**
+     * Generates a BufferedImage representation of the computed workflow graph with Format.SVG by default.
+     *
+     * @param styleAttributes the style attributes to apply to the workflow image
+     * @return the BufferedImage representation of the computed workflow graph
+     * @throws RuntimeException if an error occurs during image generation
+     */
+    default BufferedImage generateComputedWorkflowBufferedImage(List<StyleAttribute> styleAttributes) throws RuntimeException {
+        return generateComputedWorkflowBufferedImage(Format.SVG, styleAttributes);
+    }
+
+    /**
+     * Generates a BufferedImage representation of the computed workflow graph with the specified format.
+     *
+     * @param format the format of the image
+     * @return the BufferedImage representation of the computed workflow graph
+     * @throws RuntimeException if an error occurs during image generation
+     */
+    default BufferedImage generateComputedWorkflowBufferedImage(Format format) throws RuntimeException {
+        return generateComputedWorkflowBufferedImage(format, List.of());
+    }
+
+    /**
+     * Generates a BufferedImage representation of the computed workflow graph with Format.SVG by default.
+     *
+     * @return the BufferedImage representation of the computed workflow graph
+     * @throws RuntimeException if an error occurs during image generation
+     */
+    default BufferedImage generateComputedWorkflowBufferedImage() throws RuntimeException {
+        return generateComputedWorkflowBufferedImage(Format.SVG);
     }
 }

--- a/jai-workflow-core/src/main/java/io/github/czelabueno/jai/workflow/WorkflowStateName.java
+++ b/jai-workflow-core/src/main/java/io/github/czelabueno/jai/workflow/WorkflowStateName.java
@@ -2,6 +2,8 @@ package io.github.czelabueno.jai.workflow;
 
 import io.github.czelabueno.jai.workflow.transition.TransitionState;
 
+import java.util.List;
+
 /**
  * Enum representing the possible states in a workflow.
  * <p>
@@ -11,10 +13,36 @@ public enum WorkflowStateName implements TransitionState {
     /**
      * The starting state of the workflow.
      */
-    START,
+    START("_start_"),
 
     /**
      * The ending state of the workflow.
      */
-    END
+    END("_end_");
+
+    private final String graphName;
+
+    WorkflowStateName(String graphName) {
+        this.graphName = graphName;
+    }
+
+    @Override
+    public String graphName() {
+        return graphName;
+    }
+
+    @Override
+    public List<String> labels() {
+        return List.of(graphName);
+    }
+
+    @Override
+    public Object input() {
+        return Void.TYPE;
+    }
+
+    @Override
+    public Object output() {
+        return Void.TYPE;
+    }
 }

--- a/jai-workflow-core/src/main/java/io/github/czelabueno/jai/workflow/graph/Format.java
+++ b/jai-workflow-core/src/main/java/io/github/czelabueno/jai/workflow/graph/Format.java
@@ -1,0 +1,16 @@
+package io.github.czelabueno.jai.workflow.graph;
+
+/**
+ * Enum representing the format of the graph.
+ * It can be either SVG or PNG.
+ */
+public enum Format {
+    /**
+     * SVG format.
+     */
+    SVG,
+    /**
+     * PNG format.
+     */
+    PNG
+}

--- a/jai-workflow-core/src/main/java/io/github/czelabueno/jai/workflow/graph/GraphImageGenerator.java
+++ b/jai-workflow-core/src/main/java/io/github/czelabueno/jai/workflow/graph/GraphImageGenerator.java
@@ -1,8 +1,10 @@
 package io.github.czelabueno.jai.workflow.graph;
 
+import io.github.czelabueno.jai.workflow.graph.graphviz.Orientation;
+import io.github.czelabueno.jai.workflow.graph.graphviz.StyleGraph;
 import io.github.czelabueno.jai.workflow.transition.Transition;
-import lombok.NonNull;
 
+import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.util.List;
 
@@ -12,7 +14,7 @@ import java.util.List;
 public interface GraphImageGenerator {
 
     /**
-     * Generates a graph image from the given list of transitions and saves it to the default output path.
+     * Generates a graph image from the given list of transitions and saves it to the default output path: /workflow-image.svg
      *
      * @param transitions the list of transitions to generate the graph image from
      * @throws IOException if an I/O error occurs during image generation
@@ -22,12 +24,91 @@ public interface GraphImageGenerator {
     }
 
     /**
-     * Generates a graph image from the given list of transitions and saves it to the specified output path.
+     * Generates a graph image with the given format from the given list of transitions and saves it to the default output path.
+     *
+     * @param transitions the list of transitions to generate the graph image from
+     * @param format the format of the generated image
+     * @throws IOException if an I/O error occurs during image generation
+     */
+    default void generateImage(List<Transition> transitions, Format format) throws IOException {
+        generateImage(transitions, "workflow-image." + format.name().toLowerCase(), format);
+    }
+
+    /**
+     * Generates a graph image from the given list of transitions and saves it to the given output path.
+     *
+     * @param transitions the list of transitions to generate the graph image from
+     * @param format the format of the generated image
+     * @param styles the styles to apply to the generated image
+     * @throws IOException if an I/O error occurs during image generation
+     */
+    void generateImage(List<Transition> transitions, String outputPath, Format format, StyleAttribute... styles) throws IOException;
+
+    /**
+     * Generates a graph image with the given format from the given list of transitions and saves it to the specified output path.
+     *
+     * @param transitions the list of transitions to generate the graph image from
+     * @param outputPath  the path to save the generated graph image
+     * @param format the format of the generated image
+     * @throws IOException if an I/O error occurs during image generation
+     * @throws IllegalArgumentException if the output path is null or empty
+     */
+    default void generateImage(List<Transition> transitions, String outputPath, Format format) throws IOException {
+        generateImage(transitions, outputPath, format, StyleGraph.DEFAULT, Orientation.VERTICAL);
+    }
+
+    /**
+     * Generates a graph image with {@link Format}.SVG from the given list of transitions and saves it to the specified output path.
      *
      * @param transitions the list of transitions to generate the graph image from
      * @param outputPath  the path to save the generated graph image
      * @throws IOException if an I/O error occurs during image generation
      * @throws IllegalArgumentException if the output path is null or empty
      */
-    void generateImage(List<Transition> transitions, @NonNull String outputPath) throws IOException;
+    default void generateImage(List<Transition> transitions, String outputPath) throws IOException {
+        generateImage(transitions, outputPath, Format.SVG);
+    }
+
+    /**
+     * Generates a BufferedImage representation of the workflow graph from the given list of transitions.
+     *
+     * @param transitions the list of transitions to generate the graph image from
+     * @param format the format of the generated image (e.g., SVG, PNG)
+     * @param styles optional styles to apply to the graph (e.g., sketchy, orientation)
+     * @return the generated BufferedImage representation of the workflow graph
+     * @throws RuntimeException if an error occurs during image generation
+     */
+    BufferedImage generateBufferedImage(List<Transition> transitions, Format format, StyleAttribute... styles) throws RuntimeException;
+
+    /**
+     * Generates a BufferedImage representation of the workflow graph from the given list of transitions.
+     * @param transitions the list of transitions to generate the graph image from
+     * @param styles optional styles to apply to the graph (e.g., sketchy, orientation)
+     * @return the generated BufferedImage representation of the workflow graph
+     * @throws RuntimeException if an error occurs during image generation
+     */
+    default BufferedImage generateBufferedImage(List<Transition> transitions, StyleAttribute... styles) throws RuntimeException {
+        return generateBufferedImage(transitions, Format.SVG, styles);
+    }
+
+    /**
+     * Generates a BufferedImage representation of the workflow graph from the given list of transitions.
+     * @param transitions the list of transitions to generate the graph image from
+     * @param format the format of the generated image (e.g., SVG, PNG)
+     * @return the generated BufferedImage representation of the workflow graph
+     * @throws RuntimeException if an error occurs during image generation
+     */
+    default BufferedImage generateBufferedImage(List<Transition> transitions, Format format) throws RuntimeException {
+        return generateBufferedImage(transitions, format, StyleGraph.DEFAULT, Orientation.VERTICAL);
+    }
+
+    /**
+     * Generates a BufferedImage representation of the workflow graph from the given list of transitions.
+     * @param transitions the list of transitions to generate the graph image from
+     * @return the generated BufferedImage representation of the workflow graph
+     * @throws RuntimeException if an error occurs during image generation
+     */
+    default BufferedImage generateBufferedImage(List<Transition> transitions) throws RuntimeException {
+        return generateBufferedImage(transitions, Format.SVG);
+    }
 }

--- a/jai-workflow-core/src/main/java/io/github/czelabueno/jai/workflow/graph/StyleAttribute.java
+++ b/jai-workflow-core/src/main/java/io/github/czelabueno/jai/workflow/graph/StyleAttribute.java
@@ -1,0 +1,13 @@
+package io.github.czelabueno.jai.workflow.graph;
+
+/**
+ * Interface representing a style attribute.
+ */
+public interface StyleAttribute {
+    /**
+     * Gets the code representing the style attribute.
+     *
+     * @return the code representing the style attribute
+     */
+    public String getCode();
+}

--- a/jai-workflow-core/src/main/java/io/github/czelabueno/jai/workflow/graph/graphviz/GraphvizImageGenerator.java
+++ b/jai-workflow-core/src/main/java/io/github/czelabueno/jai/workflow/graph/graphviz/GraphvizImageGenerator.java
@@ -1,16 +1,33 @@
 package io.github.czelabueno.jai.workflow.graph.graphviz;
 
+import guru.nidi.graphviz.attribute.*;
+import guru.nidi.graphviz.model.Graph;
+import guru.nidi.graphviz.model.Link;
+import guru.nidi.graphviz.rough.FillStyle;
+import guru.nidi.graphviz.rough.Roughifyer;
 import io.github.czelabueno.jai.workflow.WorkflowStateName;
+import io.github.czelabueno.jai.workflow.graph.Format;
+import io.github.czelabueno.jai.workflow.graph.StyleAttribute;
+import io.github.czelabueno.jai.workflow.node.Conditional;
 import io.github.czelabueno.jai.workflow.node.Node;
+import io.github.czelabueno.jai.workflow.transition.ComputedTransition;
 import io.github.czelabueno.jai.workflow.transition.Transition;
 import io.github.czelabueno.jai.workflow.graph.GraphImageGenerator;
 import guru.nidi.graphviz.engine.*;
+import io.github.czelabueno.jai.workflow.transition.TransitionState;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
-import java.util.List;
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static guru.nidi.graphviz.model.Factory.*;
+import static guru.nidi.graphviz.model.Factory.node;
+import static io.github.czelabueno.jai.workflow.graph.graphviz.Orientation.HORIZONTAL;
+import static java.util.stream.Collectors.joining;
 
 /**
  * Implementation of {@link GraphImageGenerator} that uses <a href="https://graphviz.org/">Graphviz</a> java library and DOT language to generate workflow images.
@@ -18,12 +35,14 @@ import java.util.List;
 public class GraphvizImageGenerator implements GraphImageGenerator {
 
     private static final Logger log = LoggerFactory.getLogger(GraphvizImageGenerator.class);
+    private static final Map<TransitionState, Boolean> onceComputedTransition = new HashMap<>();
 
     private String dotFormat;
-    private static final Format DEFAULT_IMAGE_FORMAT = Format.SVG;
+    private List<ComputedTransition> computedTransitions;
 
     private GraphvizImageGenerator(GraphvizImageGeneratorBuilder builder) {
         this.dotFormat = builder.dotFormat;
+        this.computedTransitions = builder.computedTransitions;
     }
 
     /**
@@ -40,30 +59,70 @@ public class GraphvizImageGenerator implements GraphImageGenerator {
      *
      * @param transitions the list of transitions to generate the graph image from
      * @param outputPath  the path to save the generated graph image
+     * @param format      the format of the generated image (e.g., SVG, PNG)
+     * @param styles      optional styles to apply to the graph (e.g., sketchy, orientation)
      * @throws IOException if an I/O error occurs during image generation
      * @throws IllegalArgumentException if the output path is null or empty
      */
     @Override
-    public void generateImage(List<Transition> transitions, String outputPath) throws IOException {
+    public void generateImage(List<Transition> transitions, String outputPath, Format format, StyleAttribute... styles) throws IOException {
         if (outputPath == null || outputPath.isEmpty()) {
             throw new IllegalArgumentException("Output path can not be null or empty. Cannot generate image.");
         }
-        // Generate image using Graphviz from dot format
+        log.debug("Saving workflow image..");
+        createRenderer(transitions, format, styles).toFile(new File(outputPath));
+        log.debug("Workflow image saved to: " + outputPath);
+    }
+
+    /**
+     * Generates a BufferedImage representation of the workflow graph from the given list of transitions.
+     *
+     * @param transitions the list of transitions to generate the graph image from
+     * @param format the format of the generated image (e.g., SVG, PNG)
+     * @param styles optional styles to apply to the graph (e.g., sketchy, orientation)
+     * @return the generated BufferedImage representation of the workflow graph
+     * @throws RuntimeException if an error occurs during image generation
+     */
+    @Override
+    public BufferedImage generateBufferedImage(List<Transition> transitions, Format format, StyleAttribute... styles) throws RuntimeException {
         log.debug("Generating workflow image..");
-        Graphviz.useEngine(new GraphvizJdkEngine()); // Use GraalJS as the default engine
-        log.debug("Using default image format: " + DEFAULT_IMAGE_FORMAT);
-        if (dotFormat == null) {
+        Renderer renderer = createRenderer(transitions, format, styles);
+        log.debug("Workflow image rendered to BufferedImage.");
+        return renderer.toImage();
+    }
+
+    private Renderer createRenderer(List<Transition> transitions, Format format, StyleAttribute... styles) {
+        // Generate image using Graphviz from dot format
+        final guru.nidi.graphviz.engine.Format IMAGE_FORMAT = graphvizFormatFrom(format);
+        log.debug("Using default image format: " + IMAGE_FORMAT);
+
+        boolean useDotFormat = dotFormat != null;
+        Graphviz.useEngine(List.of(new GraphvizJdkEngine())); // Use GraalJS as the default engine
+
+        Graphviz gv;
+        if (useDotFormat) { // Custom dot format don't need transitions
+            log.debug("Using custom Dot format: " + System.lineSeparator() + dotFormat);
+            gv = Graphviz.fromString(dotFormat);
+        } else {
             if (transitions == null || transitions.isEmpty()) {
                 throw new IllegalArgumentException("Transitions list can not be null or empty when dotFormat is null. Cannot generate image.");
             }
-            dotFormat = defaultDotFormat(transitions);
+            gv = Graphviz.fromGraph(createGraph(transitions, computedTransitions, styles)); //JS engine is used by default
         }
-        log.debug("Using Dot format: " + System.lineSeparator() + dotFormat);
-        log.debug("Saving workflow image..");
-        Graphviz.fromString(dotFormat)
-                .render(DEFAULT_IMAGE_FORMAT)
-                .toFile(new File(outputPath));
-        log.debug("Workflow image saved to: " + outputPath);
+        if (styles != null && styles.length > 0) {
+            Graphviz finalGv = gv;
+            gv = Arrays.stream(styles)
+                    .filter(style -> style == StyleGraph.SKETCHY)
+                    .findFirst()
+                    .map(style -> finalGv.processor(new Roughifyer(new JdkJavascriptEngine()) // Use Roughifyer for sketchy style
+                            .bowing(2)
+                            .curveStepCount(6)
+                            .roughness(1)
+                            .fillStyle(FillStyle.hachure().width(2).gap(5).angle(0))
+                            .font("*serif", "Comic Sans MS")))
+                    .orElse(gv);
+        }
+        return gv.render(IMAGE_FORMAT);
     }
 
     /**
@@ -71,6 +130,7 @@ public class GraphvizImageGenerator implements GraphImageGenerator {
      */
     public static class GraphvizImageGeneratorBuilder {
         private String dotFormat;
+        private List<ComputedTransition> computedTransitions;
 
         /**
          * Sets the dot format for the graph image.
@@ -80,6 +140,17 @@ public class GraphvizImageGenerator implements GraphImageGenerator {
          */
         public GraphvizImageGeneratorBuilder dotFormat(String dotFormat) {
             this.dotFormat = dotFormat;
+            return this;
+        }
+
+        /**
+         * Sets the computed transitions for the graph image.
+         *
+         * @param computedTransitions the list of computed transitions
+         * @return the current {@link GraphvizImageGeneratorBuilder} instance
+         */
+        public GraphvizImageGeneratorBuilder computedTransitions(List<ComputedTransition> computedTransitions) {
+            this.computedTransitions = computedTransitions;
             return this;
         }
 
@@ -94,11 +165,14 @@ public class GraphvizImageGenerator implements GraphImageGenerator {
     }
 
     /**
-     * Generates the default dot format string from the given list of transitions.
+     * Generates the default DOT format string from the given list of transitions.
+     * This method is deprecated, and it is recommended to use the {@link #createGraph(List, List, StyleAttribute...)} method instead.
      *
      * @param transitions the list of transitions
-     * @return the generated dot format string
+     * @return the generated DOT format string
+     * @deprecated Use {@link #createGraph(List, List, StyleAttribute...)} for generating the graph representation.
      */
+    @Deprecated
     private String defaultDotFormat(List<Transition> transitions) {
         StringBuilder sb = new StringBuilder();
         sb.append("digraph workflow {").append(System.lineSeparator());
@@ -141,35 +215,169 @@ public class GraphvizImageGenerator implements GraphImageGenerator {
     }
 
     /**
-     * Sanitizes the node name by removing special characters and converting it to camel case.
+     * Creates a graph representation from the given list of transitions.
+     *
+     * @param transitions the list of transitions
+     * @param styles      optional styles to apply to the graph (e.g., orientation)
+     * @return the generated graph representation
+     */
+    private static Graph createGraph(List<Transition> transitions, List<ComputedTransition> computedTransitions, StyleAttribute... styles) {
+        Rank.RankDir rankDir = Arrays.stream(styles)
+                .filter(style -> style == HORIZONTAL)
+                .findFirst()
+                .map(style -> Rank.RankDir.LEFT_TO_RIGHT)
+                .orElse(Rank.RankDir.TOP_TO_BOTTOM);
+
+        boolean useComputedTransitions = computedTransitions != null && !computedTransitions.isEmpty();
+        onceComputedTransition.clear();
+        List<guru.nidi.graphviz.model.Node> nodes = transitions.stream()
+                .map(transition -> {
+                    if (useComputedTransitions) {
+                        boolean wasExecuted = computedTransitions.stream()
+                                .anyMatch(computedTransition -> computedTransition.getTransition().equals(transition));
+                        return createComputedGraphNode(transition, wasExecuted);
+                    } else {
+                        return createDefinitionGraphNode(transition);
+                    }
+                })
+                .collect(Collectors.toList());
+
+        // Count the occurrences of each node name
+        Map<Label, Long> nodeNameCounts = nodes.stream()
+                .collect(Collectors.groupingBy(guru.nidi.graphviz.model.Node::name, Collectors.counting()));
+
+        // Style nodes that have multiple occurrences computed as executed
+        List<guru.nidi.graphviz.model.Node> newNodes = nodes.stream()
+                .map(node -> {
+                    if (nodeNameCounts.get(node.name()) > 1 && onceComputedTransition.keySet().stream()
+                            .anyMatch(transitionState -> sanitizeNodeName(transitionState.graphName()).equals(node.name().value()))) {
+                        return node.with(Style.ROUNDED, Color.rgb(40, 167, 70), Color.rgb(91, 154, 119).fill());
+                    }
+                    return node;
+                })
+                .collect(Collectors.toUnmodifiableList());
+
+
+        return graph("workflow").directed()
+                .graphAttr().with(GraphAttr.splines(GraphAttr.SplineMode.POLYLINE), GraphAttr.CENTER, Rank.dir(rankDir))
+                .nodeAttr().with(Shape.RECTANGLE, Color.LIGHTBLUE2, Style.ROUNDED, Font.name("arial"))
+                .linkAttr().with(Color.DARKGREEN, Style.SOLID, Arrow.NORMAL.size(0.8))
+                .with(newNodes);
+    }
+
+    /**
+     * Creates a Graphviz node representation from the given transition.
+     *
+     * @param transition the transition to create the Graphviz node from
+     * @return the created Graphviz node
+     */
+    private static guru.nidi.graphviz.model.Node createComputedGraphNode (Transition transition, boolean wasExecuted) {
+        if (transition.from() == WorkflowStateName.START) {
+            return createDefinitionGraphNode(transition);
+        } else if (transition.to() == WorkflowStateName.END) {
+            Link linkToEnd = to(node(WorkflowStateName.END.graphName())
+                    .with(Shape.M_SQUARE, Color.GREEN, Style.FILLED, Color.rgb(217, 255, 212).fill()));
+            if (!wasExecuted) linkToEnd.add(Color.rgb(157, 165, 171));
+            return styleNodeOnce(transition.from(), wasExecuted)
+                    .link(linkToEnd);
+        } else if (transition.from() instanceof Conditional) {
+            return styleNodeOnce(transition.from(), wasExecuted)
+                    .link(createLinkStyled(transition.to(), wasExecuted).add(Style.DASHED));
+        } else {
+            return styleNodeOnce(transition.from(), wasExecuted)
+                    .link(createLinkStyled(transition.to(), wasExecuted));
+        }
+    }
+
+    private static guru.nidi.graphviz.model.Node styleNodeOnce (TransitionState transitionState, Boolean wasExecuted) {
+        if (onceComputedTransition.containsKey(transitionState) && onceComputedTransition.get(transitionState)) {
+            return getGraphvizNodeFromNode(transitionState);
+        }
+        if (!onceComputedTransition.containsKey(transitionState) && wasExecuted) {
+            onceComputedTransition.put(transitionState, true);
+            return createNodeStyled(transitionState, true);
+        }
+        return createNodeStyled(transitionState, wasExecuted);
+    }
+
+    private static guru.nidi.graphviz.model.Node createNodeStyled (TransitionState transitionState, Boolean wasExecuted) {
+        if (wasExecuted) {
+            return getGraphvizNodeFromNode(transitionState)
+                    .with(Color.rgb(40, 167, 70), Color.rgb(91, 154, 119).fill());
+        } else {
+            return getGraphvizNodeFromNode(transitionState)
+                    .with(Color.rgb(157, 165, 171), Style.combine(Style.ROUNDED, Style.DASHED), Color.rgb(108, 117, 125).fill());
+        }
+    }
+
+    private static Link createLinkStyled (TransitionState to, Boolean wasExecuted) {
+        if (wasExecuted) {
+            return to(getGraphvizNodeFromNode(to));
+        } else {
+            return to(getGraphvizNodeFromNode(to)).with(Color.rgb(157, 165, 171));
+        }
+    }
+
+    private static guru.nidi.graphviz.model.Node createDefinitionGraphNode (Transition transition) {
+        if (transition.from() == WorkflowStateName.START) {
+            return node(WorkflowStateName.START.graphName()).with(Shape.M_DIAMOND, Color.ORANGE, Style.FILLED, Color.rgb(255, 240, 212).fill())
+                    .link(getGraphvizNodeFromNode(transition.to()));
+        } else if (transition.to() == WorkflowStateName.END) {
+            return getGraphvizNodeFromNode(transition.from())
+                    .link(node(WorkflowStateName.END.graphName()).with(Shape.M_SQUARE, Color.GREEN, Style.FILLED, Color.rgb(217, 255, 212).fill()));
+        } else if (transition.from() instanceof Conditional) {
+            return getGraphvizNodeFromNode(transition.from())
+                    .link(to(getGraphvizNodeFromNode(transition.to())).with(Style.DASHED));
+        } else {
+            return getGraphvizNodeFromNode(transition.from())
+                    .link(getGraphvizNodeFromNode(transition.to()));
+        }
+    }
+
+    private static guru.nidi.graphviz.model.Node getGraphvizNodeFromNode(TransitionState transitionState) {
+        if (transitionState instanceof Node) {
+            Node node = (Node) transitionState;
+            List<String> labels = node.labels();
+            String l = "";
+            if (labels != null && !labels.isEmpty()) {
+                l = labels.stream().map(label -> "<b><i>"+label.toLowerCase()+"</i></b><br/>").collect(joining());
+            }
+            Label label = Label.html(l.concat(sanitizeNodeName(node.graphName())));
+            if (node.hasLabel("Split") || node.hasLabel("Merge")) {
+                return node(sanitizeNodeName(node.graphName())).with(label, Color.ORANGE); // style with labels
+            }
+            return node(sanitizeNodeName(node.graphName())).with(label);
+        } else if (transitionState instanceof Conditional) {
+            Conditional node = (Conditional) transitionState;
+            Label label = Label.html(node.graphName());
+            return node(sanitizeNodeName(transitionState.graphName())).with(label,Shape.DIAMOND, Font.size(10));
+        }
+        return node(sanitizeNodeName(transitionState.graphName()));
+    }
+
+    /**
+     * Sanitizes the node name by removing special characters and converting it to Java naming convention.
      *
      * @param nodeName the node name to sanitize
      * @return the sanitized node name
      */
     private static String sanitizeNodeName(String nodeName) {
-        // Remove special characters
-        String sanitized = nodeName.replaceAll("[^a-zA-Z0-9 ]", "");
+        // Convert to camel case following Java naming convention
+        return Arrays.stream(nodeName.replaceAll("[^a-zA-Z0-9 ]", "").split(" "))
+                .filter(word -> !word.isEmpty())
+                .map(word -> word.substring(0, 1).toUpperCase() + word.substring(1).toLowerCase())
+                .collect(joining())
+                .replaceFirst("^[A-Z]", nodeName.substring(0, 1).toLowerCase());
+    }
 
-        // Convert to camel case
-        String[] words = sanitized.split(" ");
-        StringBuilder camelCase = new StringBuilder();
-
-        for (int i = 0; i < words.length; i++) {
-            if (words[i].isEmpty()) {
-                continue;
-            }
-            if (i == 0) {
-                camelCase.append(words[i].substring(0, 1).toUpperCase());
-                if (words[i].length() > 1) {
-                    camelCase.append(words[i].substring(1).toLowerCase());
-                }
-            } else {
-                camelCase.append(words[i].substring(0, 1).toUpperCase());
-                if (words[i].length() > 1) {
-                    camelCase.append(words[i].substring(1).toLowerCase());
-                }
-            }
+    private static guru.nidi.graphviz.engine.Format graphvizFormatFrom(Format format) {
+        switch (format) {
+            case SVG:
+                return guru.nidi.graphviz.engine.Format.SVG;
+            case PNG:
+                return guru.nidi.graphviz.engine.Format.PNG;
+            default:
+                return guru.nidi.graphviz.engine.Format.SVG;
         }
-        return camelCase.toString();
     }
 }

--- a/jai-workflow-core/src/main/java/io/github/czelabueno/jai/workflow/graph/graphviz/Orientation.java
+++ b/jai-workflow-core/src/main/java/io/github/czelabueno/jai/workflow/graph/graphviz/Orientation.java
@@ -1,0 +1,33 @@
+package io.github.czelabueno.jai.workflow.graph.graphviz;
+
+import io.github.czelabueno.jai.workflow.graph.StyleAttribute;
+
+/**
+ * Enum representing the orientation of the graph in Graphviz.
+ * It can be either vertical (top to bottom) or horizontal (left to right).
+ */
+public enum Orientation implements StyleAttribute {
+    /**
+     * Vertical orientation (top to bottom).
+     */
+    VERTICAL("TB"),
+    /**
+     * Horizontal orientation (left to right).
+     */
+    HORIZONTAL("LR");
+
+    private final String code;
+
+    Orientation(String code) {
+        this.code = code;
+    }
+
+    /**
+     * Gets the code representing the orientation.
+     *
+     * @return the code representing the orientation
+     */
+    public String getCode() {
+        return code;
+    }
+}

--- a/jai-workflow-core/src/main/java/io/github/czelabueno/jai/workflow/graph/graphviz/StyleGraph.java
+++ b/jai-workflow-core/src/main/java/io/github/czelabueno/jai/workflow/graph/graphviz/StyleGraph.java
@@ -1,0 +1,34 @@
+package io.github.czelabueno.jai.workflow.graph.graphviz;
+
+import io.github.czelabueno.jai.workflow.graph.StyleAttribute;
+
+/**
+ * Enum representing the style of the graph in Graphviz.
+ * It can be either default or sketchy.
+ */
+public enum StyleGraph implements StyleAttribute {
+    /**
+     * Default style.
+     */
+    DEFAULT("default"),
+    /**
+     * Sketchy style.
+     */
+    SKETCHY("sketchy");
+
+    private final String code;
+
+    StyleGraph(String code) {
+        this.code = code;
+    }
+
+    /**
+     * Gets the code representing the style.
+     *
+     * @return the code representing the style
+     */
+    @Override
+    public String getCode() {
+        return code;
+    }
+}

--- a/jai-workflow-core/src/main/java/io/github/czelabueno/jai/workflow/node/Conditional.java
+++ b/jai-workflow-core/src/main/java/io/github/czelabueno/jai/workflow/node/Conditional.java
@@ -1,13 +1,15 @@
 package io.github.czelabueno.jai.workflow.node;
 
 import io.github.czelabueno.jai.workflow.transition.TransitionState;
+import lombok.Getter;
 import lombok.NonNull;
 
+import java.util.List;
 import java.util.Objects;
 import java.util.function.Function;
 
 /**
- * Represents a conditional node in a workflow that evaluates a condition function.
+ * Represents a conditional node in a workflow that evaluates a condition function to transition a new jAI workflow state.
  * <p>
  * Implements the {@link TransitionState} interface.
  *
@@ -15,16 +17,28 @@ import java.util.function.Function;
  */
 public class Conditional<T> implements TransitionState {
 
-    private final Function<T, Node<T,?>> condition;
+    private final String name;
+    private Function<T, Node<T,?>> condition;
+    @Getter
+    private final List<Node<T,?>> expectedNodes;
+    private T functionInput;
+    private Node<T,?> functionOutput;
 
     /**
-     * Constructs a Conditional with the specified condition function.
+     * Constructs a Conditional with the specified condition function and valid node types list.
      *
      * @param condition the condition function to evaluate
-     * @throws NullPointerException if the condition function is null
+     * @param expectedNodes the list of nodes expected from the condition function
+     * @throws NullPointerException if the condition function or expected node list is null
+     * @throws IllegalArgumentException if the expected node list is empty or the condition function's return type is not valid
      */
-    public Conditional(@NonNull Function<T, Node<T,?>> condition) {
+    public Conditional(String name, @NonNull Function<T, Node<T,?>> condition, @NonNull List<Node<T,?>> expectedNodes) {
         this.condition = Objects.requireNonNull(condition, "Condition function cannot be null");
+        this.expectedNodes = Objects.requireNonNull(expectedNodes, "The list of nodes expected from the condition function cannot be null");
+        if (expectedNodes.isEmpty()) {
+            throw new IllegalArgumentException("The list of nodes expected from the condition function cannot be empty");
+        }
+        this.name= name;
     }
 
     /**
@@ -36,18 +50,27 @@ public class Conditional<T> implements TransitionState {
      */
     public Node<T,?> evaluate(T input) {
         Objects.requireNonNull(input, "Function Input cannot be null");
-        return condition.apply(input);
+        functionInput = input;
+        condition = condition.andThen(resultNode -> {
+            if (!expectedNodes.contains(resultNode)) {
+                throw new RuntimeException("The condition function returned an invalid node type. Expected one of: " + expectedNodes + " but got: " + resultNode.getName() + " instead.");
+            }
+            return resultNode;
+        });
+        functionOutput = condition.apply(input);
+        return functionOutput;
     }
 
     /**
      * Creates a new Conditional with the specified condition function.
      *
      * @param condition the condition function to evaluate
+     * @param expectedNodes the list of nodes expected from the condition function
      * @param <T> the stateful bean as input to the condition function
      * @return a new Conditional instance
      */
-    public static <T> Conditional<T> eval(Function<T, Node<T,?>> condition) {
-        return new Conditional<>(condition);
+    public static <T> Conditional<T> eval(String name, Function<T, Node<T, ?>> condition, List<Node<T, ?>> expectedNodes) {
+        return new Conditional<>(name, condition, expectedNodes);
     }
 
     @Override
@@ -57,18 +80,61 @@ public class Conditional<T> implements TransitionState {
 
         Conditional<?> that = (Conditional<?>) o;
 
-        return Objects.equals(condition, that.condition);
+        return Objects.equals(condition, that.condition) &&
+                Objects.equals(expectedNodes, that.expectedNodes) &&
+                Objects.equals(name, that.name);
     }
 
     @Override
     public int hashCode() {
-        return condition != null ? condition.hashCode() : 0;
+        int result = condition != null ? condition.hashCode() : 0;
+        result = 31 * result + (expectedNodes != null ? expectedNodes.hashCode() : 0);
+        result = 31 * result + (name != null ? name.hashCode() : 0);
+        return result;
     }
 
     @Override
     public String toString() {
         return "Conditional{" +
-                "condition=" + condition +
+                "name='" + name +
+                ", condition=" + condition +
+                ", validNodes=" + expectedNodes +
                 '}';
+    }
+
+    /**
+     * Returns the name formatted for the graph.
+     *
+     * @return the name formatted for the graph.
+     */
+    @Override
+    public String graphName() {
+        if (name != null) {
+            return name.toLowerCase();
+        }
+        return "Conditional".toLowerCase();
+    }
+
+    /**
+     * Returns the labels for {@link Conditional}.
+     *
+     * @return the labels for a Conditional Node.
+     */
+    @Override
+    public List<String> labels() {
+        return List.of("Conditional");
+    }
+
+    @Override
+    public Object input() {
+        return functionInput;
+    }
+
+    @Override
+    public Object output() {
+        if (functionOutput == null) {
+            return null;
+        }
+        return functionOutput.getName(); // Node name
     }
 }

--- a/jai-workflow-core/src/main/java/io/github/czelabueno/jai/workflow/node/Node.java
+++ b/jai-workflow-core/src/main/java/io/github/czelabueno/jai/workflow/node/Node.java
@@ -4,25 +4,32 @@ import io.github.czelabueno.jai.workflow.transition.TransitionState;
 import lombok.Getter;
 import lombok.NonNull;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Objects;
 import java.util.function.Function;
 
+import static java.util.Collections.emptyList;
+
 /**
- * Represents a node in a workflow that executes a function with a given input and produces an output.
+ * Represents a Node in a workflow that executes a function with a given input and produces an output.
+ * <p>
+ * A Node represents a single unit of work within the workflow. It encapsulates a specific function or task that processes the stateful bean and updates it.
+ * </p>
  * <p>
  * This class implements the {@link TransitionState} interface.
- *
- * @param <T> the type of the input to the function. Normally a stateful bean POJO defined by the user.
- * @param <R> the type of the output from the function. Normally a stateful bean POJO defined by the user.
+ * </p>
+ * @param <T> the type of the input to the function. Usually a stateful bean POJO defined by the user.
+ * @param <R> the type of the output from the function. Usually a stateful bean POJO defined by the user.
  */
 public class Node<T, R> implements TransitionState {
 
     @Getter
     private final String name;
     private final Function<T, R> function;
-    @Getter
+    private List<String> labels;
     private T functionInput;
-    @Getter
     private R functionOutput;
 
     /**
@@ -42,6 +49,48 @@ public class Node<T, R> implements TransitionState {
     }
 
     /**
+     * Adds the specified labels to the Node.
+     *
+     * @param labels the labels to add
+     */
+    public void setLabels(String... labels) {
+        if (this.labels == null) {
+            this.labels = new ArrayList<>(Arrays.asList(labels));
+        } else {
+            this.labels.addAll(Arrays.asList(labels));
+        }
+    }
+
+    /**
+     * Gets the label for the Node.
+     *
+     * @param label the label to get
+     * @return the label for the Node
+     */
+    public String getLabel(String label) {
+        if (labels == null) {
+            return null;
+        }
+        return labels.stream()
+                .filter(l -> l.equals(label))
+                .findFirst()
+                .orElse(null);
+    }
+
+    /**
+     * Checks if the Node has the specified label.
+     *
+     * @param label the label to check
+     * @return true if the Node has the label, false otherwise
+     */
+    public boolean hasLabel(String label) {
+        if (labels == null) {
+            return false;
+        }
+        return labels.contains(label);
+    }
+
+    /**
      * Executes the function with the given input and stores the input and output.
      *
      * @param input the input to the function
@@ -52,8 +101,8 @@ public class Node<T, R> implements TransitionState {
         if (input == null) {
             throw new IllegalArgumentException("Function input cannot be null");
         }
-        R output = function.apply(input);
         functionInput = input;
+        R output = function.apply(input);
         functionOutput = output;
         return output;
     }
@@ -95,5 +144,35 @@ public class Node<T, R> implements TransitionState {
                 "name='" + name + '\'' +
                 ", function=" + function +
                 '}';
+    }
+
+    /**
+     * Returns the name formatted for the graph.
+     *
+     * @return the name formatted for the graph.
+     */
+    @Override
+    public String graphName() {
+        return name.toLowerCase();
+    }
+
+    /**
+     * Returns the labels for a Node.
+     *
+     * @return the labels for a Node.
+     */
+    @Override
+    public List<String> labels() {
+        return labels != null ? labels : emptyList();
+    }
+
+    @Override
+    public Object input() {
+        return functionInput;
+    }
+
+    @Override
+    public Object output() {
+        return functionOutput;
     }
 }

--- a/jai-workflow-core/src/main/java/io/github/czelabueno/jai/workflow/transition/ComputedTransition.java
+++ b/jai-workflow-core/src/main/java/io/github/czelabueno/jai/workflow/transition/ComputedTransition.java
@@ -1,0 +1,82 @@
+package io.github.czelabueno.jai.workflow.transition;
+
+import lombok.Getter;
+import lombok.NonNull;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/**
+ * Represents a computed transition in a jai workflow.
+ */
+@Getter
+public class ComputedTransition{
+    private final UUID id;
+    private final Integer order;
+    private final Transition transition;
+    private final LocalDateTime computedAt;
+    private final Object payload;
+
+    private ComputedTransition(@NonNull Integer order, @NonNull Transition transition) {
+        if (transition.from() == null) {
+            throw new RuntimeException("Transition node 'from' cannot be null");
+        }
+        if (transition.to() == null) {
+            throw new RuntimeException("Transition node 'to' cannot be null");
+        }
+        if (order <= 0) {
+            throw new RuntimeException("Transition order cannot be negative");
+        }
+        this.id = UUID.randomUUID();
+        this.order = order;
+        this.transition = transition;
+        this.computedAt = LocalDateTime.now();
+        this.payload = transition.from().output();
+    }
+
+    /**
+     * Creates a new ComputedTransition with the specified order and transition.
+     *
+     * @param order the order of the transition
+     * @param transition the transition to compute
+     * @return a new ComputedTransition instance
+     */
+    public static ComputedTransition from(@NonNull Integer order, @NonNull Transition transition) {
+        return new ComputedTransition(order, transition);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        ComputedTransition that = (ComputedTransition) o;
+
+        if (!id.equals(that.id)) return false;
+        if (!order.equals(that.order)) return false;
+        if (!transition.equals(that.transition)) return false;
+        if (!computedAt.equals(that.computedAt)) return false;
+        return payload.equals(that.payload);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = id.hashCode();
+        result = 31 * result + order.hashCode();
+        result = 31 * result + transition.hashCode();
+        result = 31 * result + computedAt.hashCode();
+        result = 31 * result + (payload != null ? payload.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "ComputedTransition{" +
+                "id=" + id +
+                ", order=" + order +
+                ", transition=" + transition +
+                ", computedAt=" + computedAt +
+                ", payload=" + payload +
+                '}';
+    }
+}

--- a/jai-workflow-core/src/main/java/io/github/czelabueno/jai/workflow/transition/Transition.java
+++ b/jai-workflow-core/src/main/java/io/github/czelabueno/jai/workflow/transition/Transition.java
@@ -9,7 +9,7 @@ import lombok.NonNull;
  * The states can be instances of {@link Node} or {@link WorkflowStateName}.
  *
  */
-public record Transition(TransitionState from, TransitionState to) {
+public record Transition (TransitionState from, TransitionState to) {
 
     /**
      * Constructs a Transition with the specified from and to states.
@@ -46,6 +46,24 @@ public record Transition(TransitionState from, TransitionState to) {
         return new Transition(from, to);
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Transition that = (Transition) o;
+
+        if (!from.equals(that.from)) return false;
+        return to.equals(that.to);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = from.hashCode();
+        result = 31 * result + to.hashCode();
+        return result;
+    }
+
     /**
      * Returns a string representation of the transition.
      *
@@ -54,20 +72,8 @@ public record Transition(TransitionState from, TransitionState to) {
     @Override
     public String toString() {
         String transition = "";
-        if (from instanceof Node) {
-            transition = ((Node) from).getName() + " -> ";
-        } else if (from instanceof WorkflowStateName) {
-            transition = ((WorkflowStateName) from).toString() + " -> ";
-        } else {
-            transition = from.toString() + " -> ";
-        }
-        if (to instanceof Node) {
-            transition = transition + ((Node) to).getName();
-        } else if (to instanceof WorkflowStateName) {
-            transition = transition + ((WorkflowStateName) to).toString();
-        } else {
-            transition = transition + to.toString();
-        }
+        if (from != null) transition = from.graphName() + " -> ";
+        if (to != null) transition = transition + to.graphName();
         return transition;
     }
 }

--- a/jai-workflow-core/src/main/java/io/github/czelabueno/jai/workflow/transition/TransitionState.java
+++ b/jai-workflow-core/src/main/java/io/github/czelabueno/jai/workflow/transition/TransitionState.java
@@ -1,10 +1,55 @@
 package io.github.czelabueno.jai.workflow.transition;
 
+import java.util.List;
+
 /**
- * Marker interface representing a state in a workflow transition.
+ * Represents a component in the jAI workflow anatomy that can produce a transition and update the workflow state.
  * <p>
- * Classes implementing this interface can be used as states in a {@link Transition}.
+ * For example, a {@link io.github.czelabueno.jai.workflow.node.Node} can produce a transition by executing a function.
+ * </p>
+ * <p>
+ * Classes implementing this interface can be used to generate a state as part of a {@link Transition}.
  * </p>
  */
 public interface TransitionState{
+
+    /**
+     * Returns the name of the state in the graph.
+     *
+     * @return the name of the state in the graph
+     */
+    String graphName();
+
+    /**
+     * Returns the labels of the state in the graph.
+     *
+     * @return the labels of the state in the graph
+     */
+    List<String> labels();
+
+    /**
+     * Checks if the state has a given label.
+     *
+     * @param label the label to check
+     * @return true if the state has the given label, false otherwise
+     */
+    default boolean hasLabel(String label){
+        if (labels() == null) {
+            return false;
+        }
+        return labels().contains(label);
+    }
+    /**
+     * Returns the input of the state.
+     *
+     * @return the input of the state
+     */
+    Object input();
+
+    /**
+     * Returns the output of the state.
+     *
+     * @return the output of the state
+     */
+    Object output();
 }

--- a/jai-workflow-core/src/test/java/io/github/czelabueno/jai/workflow/StateWorkflowTest.java
+++ b/jai-workflow-core/src/test/java/io/github/czelabueno/jai/workflow/StateWorkflowTest.java
@@ -1,23 +1,33 @@
 package io.github.czelabueno.jai.workflow;
 
+import io.github.czelabueno.jai.workflow.graph.Format;
+import io.github.czelabueno.jai.workflow.graph.graphviz.GraphvizImageGenerator;
+import io.github.czelabueno.jai.workflow.graph.graphviz.Orientation;
+import io.github.czelabueno.jai.workflow.graph.graphviz.StyleGraph;
 import io.github.czelabueno.jai.workflow.node.Conditional;
 import io.github.czelabueno.jai.workflow.node.Node;
+import io.github.czelabueno.jai.workflow.transition.ComputedTransition;
+import io.github.czelabueno.jai.workflow.transition.Transition;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.function.Function;
 
-import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class StateWorkflowTest {
+
+    // validated
     class MyStatefulBean {
         int value = 0;
 
@@ -68,8 +78,126 @@ class StateWorkflowTest {
 
         myWorkflow = DefaultStateWorkflow.<MyStatefulBean>builder()
                 .statefulBean(myStatefulBean)
-                .addNodes(asList(node1, node2, node3, node4))
+                .addEdges(Transition.from(node1, node2), Transition.from(node2, node3))
+                .addNodes(node1, node2, node3)
                 .build();
+    }
+
+    // 1) Workflow definition test cases
+    @Test
+    void should_construct_workflow_with_minimum_values_required() {
+        // when
+        MyStatefulBean myStatefulBean2 = new MyStatefulBean();
+        myWorkflow = DefaultStateWorkflow.<MyStatefulBean>builder()
+                .statefulBean(myStatefulBean2)
+                .addEdges(Transition.from(node1, node2), Transition.from(node2, node3), Transition.from(node3, node4))
+                .build();
+        // then
+        Node lastNodeDefined = myWorkflow.getLastNode();
+        assertEquals(node4, lastNodeDefined);
+    }
+
+    @Test
+    void should_throw_illegalArgumentException_without_statefulBean() {
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> DefaultStateWorkflow.<MyStatefulBean>builder()
+                        .addEdges(Transition.from(node1, node2), Transition.from(node2, node3))
+                        .build())
+                .withMessage("Stateful bean cannot be null");
+    }
+
+    @Test
+    void should_throw_illegalArgumentException_without_edges() {
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> DefaultStateWorkflow.<MyStatefulBean>builder()
+                        .statefulBean(myStatefulBean)
+                        .addNodes(node1, node2, node3)
+                        .build())
+                .withMessage("At least one edged must be added to the workflow");
+    }
+
+    @Test
+    void should_construct_workflow_with_nodes() {
+        // when
+        myWorkflow = DefaultStateWorkflow.<MyStatefulBean>builder()
+                .statefulBean(myStatefulBean)
+                .addEdges(Transition.from(node1, node2), Transition.from(node2, node3))
+                .addNodes(node1, node2, node3)
+                .build();
+        // then
+        Node lastNodeDefined = myWorkflow.getLastNode();
+        assertEquals(node3, lastNodeDefined);
+    }
+
+    @Test
+    void should_construct_workflow_with_graphImageGenerator() {
+        // when
+        myWorkflow = DefaultStateWorkflow.<MyStatefulBean>builder()
+                .statefulBean(myStatefulBean)
+                .addEdges(Transition.from(node1, node2), Transition.from(node2, node3))
+                .graphImageGenerator(GraphvizImageGenerator.builder().build())
+                .build();
+        // then
+        Node lastNodeDefined = myWorkflow.getLastNode();
+        assertEquals(node3, lastNodeDefined);
+    }
+
+    @Test
+    void should_throw_illegalArgumentException_if_a_parallel_node_is_a_split_node() {
+        Node node5 = Node.from("node5", obj -> "node5");
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> DefaultStateWorkflow.<MyStatefulBean>builder()
+                        .statefulBean(myStatefulBean)
+                        .addEdges(Transition.from(node1, node2), Transition.from(node1, node3), Transition.from(node2, node4), Transition.from(node2, node5))
+                        .build())
+                .withMessage("A parallel node 'node2' cannot be a split node in the same flow");
+    }
+
+    @Test
+    void should_throw_illegalArgumentException_if_parallel_next_node_is_not_a_merge_node_or_parallel_node() {
+        Node node5 = Node.from("node5", obj -> "node5");
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> DefaultStateWorkflow.<MyStatefulBean>builder()
+                        .statefulBean(myStatefulBean)
+                        .addEdges(Transition.from(node1, node2), Transition.from(node1, node3), Transition.from(node1, node4), Transition.from(node2, node5), Transition.from(node3, node5))
+                        .build())
+                .withMessage("The merge node 'node5' must have the same number of input transitions as the number of output transitions from the split node 'node1'");
+    }
+
+    @Test
+    void should_throw_illegalArgumentException_if_parallel_next_node_is_a_WorkflowStateName() {
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> DefaultStateWorkflow.<MyStatefulBean>builder()
+                        .statefulBean(myStatefulBean)
+                        .addEdges(Transition.from(node1, node2), Transition.from(node1, node3), Transition.from(node2, WorkflowStateName.END))
+                        .build())
+                .withMessage("The state node2 labeled as 'Parallel' cannot have a WorkflowStateName '_end_' as an adjacent node");
+    }
+
+    // 2) Workflow building test cases
+    @Test
+    void should_construct_workflow_with_build_arg_start_node() {
+        // when
+        myWorkflow = DefaultStateWorkflow.<MyStatefulBean>builder()
+                .statefulBean(myStatefulBean)
+                .addEdges(Transition.from(node1, node2), Transition.from(node2, node3))
+                .build(node1);
+        // then
+        Node lastNodeDefined = myWorkflow.getLastNode();
+        assertEquals(node3, lastNodeDefined);
+    }
+
+    // 3) Workflow run and put edges and nodes after build test cases
+    @Test
+    void should_throw_illegalArgumentException_for_inconsistent_start_transition(){
+        // then
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> {
+                    myWorkflow.putEdge(node1, WorkflowStateName.START);
+                    myWorkflow.putEdge(node2, node3);
+                    myWorkflow.run();
+                })
+                .withMessage("Cannot transition to a START state");
     }
 
     @Test
@@ -77,8 +205,8 @@ class StateWorkflowTest {
         myWorkflow.putEdge(node1, node2);
         myWorkflow.startNode(node1);
         myWorkflow.run();
-        assertEquals(2, myWorkflow.getComputedTransitions().size()); // start -> node1 -> node2
-        assertEquals(3, myStatefulBean.value);
+        assertEquals(3, myWorkflow.getComputedTransitions().size()); // start -> node1 -> node2
+        assertEquals(6, myStatefulBean.value);
     }
 
     @Test
@@ -87,11 +215,60 @@ class StateWorkflowTest {
         myWorkflow.startNode(node1);
         myWorkflow.runStream(node -> {
             assertThat(node.getName()).containsIgnoringCase("node");
-            assertThat(node.getFunctionInput()).isNotNull(); // stateful bean must not be null
-            assertThat(node.getFunctionOutput()).asString().containsIgnoringCase("processed function");
+            assertThat(node.input()).isNotNull(); // stateful bean must not be null
+            assertThat(node.output()).asString().containsIgnoringCase("processed function");
         });
-        assertEquals(2, myWorkflow.getComputedTransitions().size()); // start -> node1 -> node2
-        assertEquals(3, myStatefulBean.value);
+        assertEquals(3, myWorkflow.getComputedTransitions().size()); // start -> node1 -> node2
+        assertEquals(6, myStatefulBean.value);
+    }
+
+    @Test
+    void should_run_stream_workflow_with_split_parallel_merge_nodes() {
+        // given
+        Node node5 = Node.from("node5", obj -> "node5");
+        Node node6 = Node.from("node6", obj -> "node6");
+        myWorkflow = DefaultStateWorkflow.<MyStatefulBean>builder()
+                .statefulBean(myStatefulBean)
+                .addEdges(Transition.from(node1, node2), // node1 is a split node
+                        Transition.from(node1, node3), // node2 is a parallel node
+                        Transition.from(node2, node4), // node3 is a parallel node
+                        Transition.from(node3, node5), // node4 is a parallel node
+                        Transition.from(node4, node6), // node5 is a parallel node
+                        Transition.from(node5, node6)) // node6 is a merge node
+                .build();
+        // when
+        myWorkflow.runStream(node -> {
+            assertThat(node.getName()).containsIgnoringCase("node");
+            if (node.getName().equals("node1")) assertThat(node.hasLabel("Split")).isTrue();
+            if (node.getName().equals("node2") || node.getName().equals("node3") || node.getName().equals("node4") || node.getName().equals("node5")) {
+                assertThat(node.hasLabel("Parallel")).isTrue();
+            }
+            if (node.getName().equals("node6")) assertThat(node.hasLabel("Merge")).isTrue();
+        });
+
+        // then
+        assertEquals(8, myWorkflow.getComputedTransitions().size()); // start -> node1 -> [node2 -> node4, node3 -> node5] -> node6 -> end
+    }
+
+    @Test
+    void should_run_stream_workflow_with_conditional_node() {
+        // given
+        myWorkflow.putEdge(node3, Conditional.eval("greater than 6?", obj -> {
+            if (obj.value > 6) {
+                return node4;
+            } else {
+                return node2; // expected return node2
+            }
+        }, List.of(node2, node4)));
+        myWorkflow.putEdge(node4, WorkflowStateName.END);
+        // when
+        myWorkflow.runStream(node -> {
+            assertThat(((MyStatefulBean)node.input()).value).isGreaterThanOrEqualTo(1);
+            assertThat(node.output()).asString().containsIgnoringCase("processed function");
+        });
+        // then
+        assertEquals(8, myWorkflow.getComputedTransitions().size()); // start -> node1 -> node2 -> node3 -> cond -> node2 -> node3 -> cond-> node4 -> end
+        assertEquals(15, myStatefulBean.value);
     }
 
     @Test
@@ -111,16 +288,17 @@ class StateWorkflowTest {
     void should_run_workflow_with_conditional_node_and_return_statefulbean_modified() {
         myWorkflow.putEdge(node1, node2);
         myWorkflow.putEdge(node2, node3);
-        myWorkflow.putEdge(node3, Conditional.eval(obj -> {
+        myWorkflow.putEdge(node3, Conditional.eval("greater than 6?", obj -> {
             if (obj.value > 6) {
                 return node4;
             } else {
                 return node2; // expected return node2
             }
-        }));
+        }, List.of(node2, node4)));
+        myWorkflow.putEdge(node4, WorkflowStateName.END);
         myWorkflow.startNode(node1);
         myWorkflow.run();
-        assertEquals(6, myWorkflow.getComputedTransitions().size()); // start -> node1 -> node2 -> node3 -> node2 -> node3 -> node4
+        assertEquals(8, myWorkflow.getComputedTransitions().size()); // start -> node1 -> node2 -> node3 -> cond -> node2 -> node3 -> cond-> node4 -> end
         assertEquals(15, myStatefulBean.value);
     }
 
@@ -130,7 +308,7 @@ class StateWorkflowTest {
         myWorkflow.putEdge(node2, WorkflowStateName.END);
         myWorkflow.startNode(node1);
         myWorkflow.run();
-        assertEquals(3, myWorkflow.getComputedTransitions().size()); // start -> node1 -> node2 -> end
+        assertEquals(2, myWorkflow.getComputedTransitions().size()); // start -> node1 -> node2 -> end
         assertEquals(3, myStatefulBean.value);
     }
 
@@ -140,33 +318,206 @@ class StateWorkflowTest {
         myWorkflow.startNode(node1);
         myWorkflow.run();
         String transitions = ((DefaultStateWorkflow)myWorkflow).prettyTransitions();
-        assertThat(2).isEqualTo(myWorkflow.getComputedTransitions().size());
+        assertThat(3).isEqualTo(myWorkflow.getComputedTransitions().size());
         assertThat(transitions).containsPattern("node\\d+ -> node\\d+");
     }
 
+    @Test
+    void should_throw_IllegalStateException_when_run_workflow_with_multiple_start_nodes() {
+        Node node5 = Node.from("node5", obj -> "node5");
+        assertThatExceptionOfType(IllegalStateException.class)
+                .isThrownBy(() -> DefaultStateWorkflow.<MyStatefulBean>builder()
+                        .statefulBean(myStatefulBean)
+                        .addEdges(Transition.from(node1, node2), // node1 is a start node
+                                Transition.from(node3, node4), // node3 is a start node too
+                                Transition.from(node2, node5),
+                                Transition.from(node4, node5))
+                        .build()
+                        .run())
+                .withMessageStartingWith("Its not possible to determine the start node, multiple start nodes found:")
+                .withMessageContaining("node1")
+                .withMessageContaining("node3")
+                .withMessageEndingWith("Please specify the start node using the .startNode(Node<T> node) method");
+    }
+
+    @Test
+    void should_throw_RuntimeException_when_call_computed_method_without_run_workflow() {
+        assertThatExceptionOfType(RuntimeException.class)
+                .isThrownBy(() -> myWorkflow.getComputedTransitions())
+                .withMessage("Workflow has not been run yet. No transitions computed");
+    }
+
+    @Test
+    void should_get_workflow_log_entries_of_computed_transitions_after_run() {
+        myWorkflow.startNode(node1);
+        myWorkflow.run();
+        List<ComputedTransition> computedTransitions = myWorkflow.getComputedTransitions();
+        computedTransitions.forEach(ct -> {
+            if (ct.getTransition().from().equals(node1)) { // getting computed transition details from node1
+                assertThat(ct.getId()).isNotNull();
+                assertThat(ct.getTransition().to()).isEqualTo(node2);
+                assertThat(ct.getPayload()).isEqualTo("Node1: processed function");
+                assertThat(ct.getOrder()).isEqualTo(1);
+                assertThat(ct.getComputedAt()).isBefore(LocalDateTime.now());
+            }
+        });
+    }
+
+    // 4) Workflow image generation test cases
     @SneakyThrows(IOException.class)
     @Test
-    void should_generate_workflow_image() {
+    void should_generate_definition_workflow_image_file_using_path() {
         myWorkflow.putEdge(node1, node2);
         myWorkflow.putEdge(node2, WorkflowStateName.END);
         myWorkflow.startNode(node1);
-        myWorkflow.run();
         String imagePath = "image/my-workflow-from-test.svg";
         myWorkflow.generateWorkflowImage(imagePath);
         Path filePath = Paths.get(imagePath);
         assertThat(Files.exists(filePath)).isTrue();
     }
 
+    @SneakyThrows(IOException.class)
     @Test
-    void should_throw_illegalArgumentException_for_inconsistent_start_transition(){
-        // given
-        myWorkflow.putEdge(node1, WorkflowStateName.START);
-        myWorkflow.putEdge(node2, node3);
-        // when
+    void should_generate_definition_workflow_image_file_using_path_and_vertical_orientation() {
+        myWorkflow.putEdge(node1, node2);
+        myWorkflow.putEdge(node2, WorkflowStateName.END);
         myWorkflow.startNode(node1);
-        // then
-        assertThatExceptionOfType(IllegalArgumentException.class)
-                .isThrownBy(() -> myWorkflow.run())
-                .withMessage("Cannot transition to a START state");
+        String imagePath = "image/my-workflow-vertical-from-test.svg";
+        myWorkflow.generateWorkflowImage(imagePath, List.of(Orientation.VERTICAL));
+        Path filePath = Paths.get(imagePath);
+        assertThat(Files.exists(filePath)).isTrue();
     }
+
+    @SneakyThrows(IOException.class)
+    @Test
+    void should_generate_definition_workflow_image_file_using_path_and_horizontal_orientation() {
+        myWorkflow.putEdge(node1, node2);
+        myWorkflow.putEdge(node2, WorkflowStateName.END);
+        myWorkflow.startNode(node1);
+        String imagePath = "image/my-workflow-horizontal-from-test.svg";
+        myWorkflow.generateWorkflowImage(imagePath, List.of(Orientation.HORIZONTAL));
+        Path filePath = Paths.get(imagePath);
+        assertThat(Files.exists(filePath)).isTrue();
+    }
+
+    @SneakyThrows(IOException.class)
+    @Test
+    void should_generate_definition_workflow_image_file_using_path_and_sketchy_styled() {
+        myWorkflow.putEdge(node1, node2);
+        myWorkflow.putEdge(node2, WorkflowStateName.END);
+        myWorkflow.startNode(node1);
+        String imagePath = "image/my-workflow-sketchy-from-test.svg";
+        myWorkflow.generateWorkflowImage(imagePath, List.of(StyleGraph.SKETCHY));
+        Path filePath = Paths.get(imagePath);
+        assertThat(Files.exists(filePath)).isTrue();
+    }
+
+    @SneakyThrows(IOException.class)
+    @Test
+    void should_generate_definition_workflow_image_PNG_file_using_path_and_sketchy_styled() {
+        myWorkflow.putEdge(node1, node2);
+        myWorkflow.putEdge(node2, WorkflowStateName.END);
+        myWorkflow.startNode(node1);
+        String imagePath = "image/my-workflow-sketchy-from-test.png";
+        myWorkflow.generateWorkflowImage(Format.PNG, imagePath, List.of(StyleGraph.SKETCHY));
+        Path filePath = Paths.get(imagePath);
+        assertThat(Files.exists(filePath)).isTrue();
+    }
+
+    @Test
+    void should_generate_definition_workflow_buffered_image() {
+        // given
+        myWorkflow.putEdge(node1, node2);
+        myWorkflow.putEdge(node2, WorkflowStateName.END);
+        myWorkflow.startNode(node1);
+        // when
+        BufferedImage image = myWorkflow.generateWorkflowBufferedImage();
+        // then
+        assertThat(image).isNotNull();
+        assertThat(image.getType()).isEqualTo(BufferedImage.TYPE_INT_ARGB);
+        assertThat(image.getWidth()).isGreaterThan(0);
+        assertThat(image.getHeight()).isGreaterThan(0);
+    }
+
+    @SneakyThrows(IOException.class)
+    @Test
+    void should_generate_computed_workflow_image_file_using_path() {
+        myWorkflow.putEdge(node1, node2);
+        myWorkflow.putEdge(node2, WorkflowStateName.END);
+        myWorkflow.startNode(node1);
+        myWorkflow.run();
+        String imagePath = "image/my-computed-workflow-from-test.svg";
+        myWorkflow.generateComputedWorkflowImage(imagePath);
+        Path filePath = Paths.get(imagePath);
+        assertThat(Files.exists(filePath)).isTrue();
+    }
+
+    @SneakyThrows(IOException.class)
+    @Test
+    void should_generate_computed_workflow_image_file_using_path_and_vertical_orientation() {
+        myWorkflow.putEdge(node1, node2);
+        myWorkflow.putEdge(node2, WorkflowStateName.END);
+        myWorkflow.startNode(node1);
+        myWorkflow.run();
+        String imagePath = "image/my-computed-workflow-vertical-from-test.svg";
+        myWorkflow.generateComputedWorkflowImage(imagePath, List.of(Orientation.VERTICAL));
+        Path filePath = Paths.get(imagePath);
+        assertThat(Files.exists(filePath)).isTrue();
+    }
+
+    @SneakyThrows(IOException.class)
+    @Test
+    void should_generate_computed_workflow_image_file_using_path_and_horizontal_orientation() {
+        myWorkflow.putEdge(node1, node2);
+        myWorkflow.putEdge(node2, WorkflowStateName.END);
+        myWorkflow.startNode(node1);
+        myWorkflow.run();
+        String imagePath = "image/my-computed-workflow-horizontal-from-test.svg";
+        myWorkflow.generateComputedWorkflowImage(imagePath, List.of(Orientation.HORIZONTAL));
+        Path filePath = Paths.get(imagePath);
+        assertThat(Files.exists(filePath)).isTrue();
+    }
+
+    @SneakyThrows(IOException.class)
+    @Test
+    void should_generate_computed_workflow_image_file_using_path_and_sketchy_styled() {
+        myWorkflow.putEdge(node1, node2);
+        myWorkflow.putEdge(node2, WorkflowStateName.END);
+        myWorkflow.startNode(node1);
+        myWorkflow.run();
+        String imagePath = "image/my-computed-workflow-sketchy-from-test.svg";
+        myWorkflow.generateComputedWorkflowImage(imagePath, List.of(StyleGraph.SKETCHY));
+        Path filePath = Paths.get(imagePath);
+        assertThat(Files.exists(filePath)).isTrue();
+    }
+
+    @SneakyThrows(IOException.class)
+    @Test
+    void should_generate_computed_workflow_image_PNG_file_using_path_and_sketchy_styled() {
+        myWorkflow.putEdge(node1, node2);
+        myWorkflow.putEdge(node2, WorkflowStateName.END);
+        myWorkflow.startNode(node1);
+        myWorkflow.run();
+        String imagePath = "image/my-computed-workflow-sketchy-from-test.png";
+        myWorkflow.generateComputedWorkflowImage(Format.PNG, imagePath, List.of(StyleGraph.SKETCHY));
+        Path filePath = Paths.get(imagePath);
+        assertThat(Files.exists(filePath)).isTrue();
+    }
+
+    @Test
+    void should_generate_computed_workflow_buffered_image() {
+        // given
+        myWorkflow.putEdge(node1, node2);
+        myWorkflow.putEdge(node2, WorkflowStateName.END);
+        myWorkflow.startNode(node1);
+        myWorkflow.run();
+        // when
+        BufferedImage image = myWorkflow.generateComputedWorkflowBufferedImage();
+        // then
+        assertThat(image).isNotNull();
+        assertThat(image.getType()).isEqualTo(BufferedImage.TYPE_INT_ARGB);
+        assertThat(image.getWidth()).isGreaterThan(0);
+        assertThat(image.getHeight()).isGreaterThan(0);
+    }
+
 }

--- a/jai-workflow-core/src/test/java/io/github/czelabueno/jai/workflow/graph/graphviz/GraphvizImageGeneratorTest.java
+++ b/jai-workflow-core/src/test/java/io/github/czelabueno/jai/workflow/graph/graphviz/GraphvizImageGeneratorTest.java
@@ -1,29 +1,63 @@
 package io.github.czelabueno.jai.workflow.graph.graphviz;
 
+import io.github.czelabueno.jai.workflow.graph.Format;
 import io.github.czelabueno.jai.workflow.node.Node;
+import io.github.czelabueno.jai.workflow.transition.ComputedTransition;
 import io.github.czelabueno.jai.workflow.transition.Transition;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.awt.image.BufferedImage;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.IntStream;
 
+import static io.github.czelabueno.jai.workflow.WorkflowStateName.END;
+import static io.github.czelabueno.jai.workflow.WorkflowStateName.START;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class GraphvizImageGeneratorTest {
 
     GraphvizImageGenerator.GraphvizImageGeneratorBuilder builder;
     String dotFormat = "digraph { a -> b; }";
 
+    List<ComputedTransition> computedTransitions;
+
+    List<Transition> transitions;
+
     @BeforeEach
     void setUp() {
         builder = GraphvizImageGenerator.builder();
+
+        // node mocked to simulate that the transition was computed
+        Node a = mock(Node.class);
+        Node b = mock(Node.class);
+        Node c = mock(Node.class);
+        when(a.output()).thenReturn("mockedPayloadOfNodeA");
+        when(b.output()).thenReturn("mockedPayloadOfNodeB");
+        when(c.output()).thenReturn("mockedPayloadOfNodeC");
+        when(a.graphName()).thenReturn("a");
+        when(b.graphName()).thenReturn("b");
+        when(c.graphName()).thenReturn("c");
+
+        transitions = Arrays.asList(
+                Transition.from(START, a),
+                Transition.from(a, b),
+                Transition.from(b, c),
+                Transition.from(c, END)
+        );
+
+        computedTransitions = IntStream.range(0, transitions.size())
+                .mapToObj(i -> ComputedTransition.from(i + 1, transitions.get(i)))
+                .toList();
     }
 
     @Test
@@ -37,7 +71,17 @@ class GraphvizImageGeneratorTest {
     }
 
     @Test
-    void test_generateImage_invalid_transitions() {
+    void test_builder_and_computed_transitions() {
+        // given
+        assertThat(builder).isNotNull();
+        // when
+        GraphvizImageGenerator generator = builder.computedTransitions(computedTransitions).build();
+        // then
+        assertThat(generator).isNotNull();
+    }
+
+    @Test
+    void test_throw_illegalArgumentException_when_generate_image_with_invalid_transitions() {
         // given
         List<Transition> transitions = Collections.EMPTY_LIST;
         // when
@@ -50,7 +94,7 @@ class GraphvizImageGeneratorTest {
     }
 
     @Test
-    void test_generate_Image_invalid_outputPath() {
+    void test_throw_illegalArgumentException_when_generate_image_with_invalid_outputPath() {
         // given
         List<Transition> transitions = Arrays.asList(
                 Transition.from(
@@ -67,10 +111,9 @@ class GraphvizImageGeneratorTest {
                 .hasMessage("Output path can not be null or empty. Cannot generate image.");
     }
 
-
     @SneakyThrows
     @Test
-    void test_generate_Image_with_custom_dotFormat() {
+    void test_generate_image_with_dotFormat_provided() {
         // given
         GraphvizImageGenerator generator = builder.dotFormat("digraph { a -> b -> c -> d; }").build();
         // when
@@ -83,7 +126,7 @@ class GraphvizImageGeneratorTest {
 
     @SneakyThrows
     @Test
-    void test_generate_Image_with_custom_outputPath() {
+    void test_generate_image_with_dotFormat_and_outputPath() {
         // given
         GraphvizImageGenerator generator = builder.dotFormat(dotFormat).build();
         // when
@@ -97,26 +140,21 @@ class GraphvizImageGeneratorTest {
 
     @SneakyThrows
     @Test
-    void test_generate_Image_with_transition_and_default_dotFormat() {
+    void test_generate_image_with_dotFormat_and_format_PNG_and_sketchy_style() {
         // given
-        List<Transition> transitions = Arrays.asList(
-                Transition.from(
-                        Node.from("a", s -> s + "1"),
-                        Node.from("b", s -> s + "2")
-                )
-        );
-        GraphvizImageGenerator generator = builder.build();
+        GraphvizImageGenerator generator = builder.dotFormat("digraph { a -> b -> c -> d; }").build();
         // when
         assertThat(generator).isNotNull();
-        generator.generateImage(transitions);
+        String strPath = "image/my-workflow-dot-styles-from-test.png";
+        generator.generateImage(null, strPath, Format.PNG, StyleGraph.SKETCHY); // transitions are not required when dotFormat is provided
         // then
-        Path path = Paths.get("workflow-image.svg");
+        Path path = Paths.get(strPath);
         assertThat(Files.exists(path)).isTrue();
     }
 
     @SneakyThrows
     @Test
-    void test_generate_Image_is_SVG_format() {
+    void test_generate_image_with_transitions() {
         // given
         List<Transition> transitions = Arrays.asList(
                 Transition.from(
@@ -129,9 +167,206 @@ class GraphvizImageGeneratorTest {
         assertThat(generator).isNotNull();
         generator.generateImage(transitions);
         // then
-        Path path = Paths.get("workflow-image.svg");
+        Path path = Paths.get("workflow-image.svg"); // default output path
         assertThat(Files.exists(path)).isTrue();
         String content = String.join("\n", Files.readAllLines(path));
-        assertThat(content.trim()).startsWith("<svg");
+        assertThat(content.trim()).startsWith("<svg"); // default image format is SVG
+    }
+
+    @SneakyThrows
+    @Test
+    void test_generate_image_with_transitions_and_outputPath() {
+        // given
+        List<Transition> transitions = Arrays.asList(
+                Transition.from(
+                        Node.from("a", s -> s + "1"),
+                        Node.from("b", s -> s + "2")
+                )
+        );
+        GraphvizImageGenerator generator = builder.build();
+        // when
+        assertThat(generator).isNotNull();
+        String strPath = "image/my-workflow-from-test.svg";
+        generator.generateImage(transitions, strPath);
+        // then
+        Path path = Paths.get(strPath);
+        assertThat(Files.exists(path)).isTrue(); // custom output path
+        String content = String.join("\n", Files.readAllLines(path));
+        assertThat(content.trim()).startsWith("<svg"); // default image format is SVG
+    }
+
+    @SneakyThrows
+    @Test
+    void test_generate_image_with_transitions_and_outputPath_and_format_PNG() {
+        // given
+        List<Transition> transitions = Arrays.asList(
+                Transition.from(
+                        Node.from("a", s -> s + "1"),
+                        Node.from("b", s -> s + "2")
+                )
+        );
+        GraphvizImageGenerator generator = builder.build();
+        // when
+        assertThat(generator).isNotNull();
+        String strPath = "image/my-workflow-from-test.png";
+        generator.generateImage(transitions, strPath, Format.PNG);
+        // then
+        Path path = Paths.get(strPath);
+        assertThat(Files.exists(path)).isTrue(); // custom output path
+        assertThat(Files.probeContentType(path)).startsWith("image/png"); // file content-type
+    }
+
+    @SneakyThrows
+    @Test
+    void test_generate_image_with_transitions_output_and_styles() {
+        // given
+        List<Transition> transitions = Arrays.asList(
+                Transition.from(
+                        Node.from("a", s -> s + "1"),
+                        Node.from("b", s -> s + "2")
+                )
+        );
+        GraphvizImageGenerator generator = builder.build();
+        // when
+        assertThat(generator).isNotNull();
+        String strPath = "image/my-workflow-from-test-sketchy.png";
+        generator.generateImage(transitions, strPath, Format.PNG, StyleGraph.SKETCHY, Orientation.HORIZONTAL);
+        // then
+        Path path = Paths.get(strPath);
+        assertThat(Files.exists(path)).isTrue(); // custom output path
+    }
+
+    @SneakyThrows
+    @Test
+    void test_buffered_image_with_all_params() {
+        // given
+        List<Transition> transitions = Arrays.asList(
+                Transition.from(
+                        Node.from("a", s -> s + "1"),
+                        Node.from("b", s -> s + "2")
+                )
+        );
+        GraphvizImageGenerator generator = builder.build();
+        // when
+        assertThat(generator).isNotNull();
+        BufferedImage image = generator.generateBufferedImage(
+                transitions,
+                Format.SVG,
+                StyleGraph.SKETCHY, // style attribute
+                Orientation.HORIZONTAL); // style attribute
+        // then
+        assertThat(image).isNotNull();
+        assertThat(image.getType()).isEqualTo(BufferedImage.TYPE_INT_ARGB);
+        assertThat(image.getWidth()).isGreaterThan(0);
+        assertThat(image.getHeight()).isGreaterThan(0);
+    }
+
+    @SneakyThrows
+    @Test
+    void test_buffered_image_with_dotFormat_and_styles() {
+        // given
+        GraphvizImageGenerator generator = builder.dotFormat("digraph { a -> b -> c -> d; }").build();
+        // when
+        assertThat(generator).isNotNull();
+        BufferedImage image = generator.generateBufferedImage(null,
+                Format.SVG,
+                StyleGraph.SKETCHY, // style attribute
+                Orientation.HORIZONTAL); // style attribute
+        // then
+        assertThat(image).isNotNull();
+        assertThat(image.getType()).isEqualTo(BufferedImage.TYPE_INT_ARGB);
+        assertThat(image.getWidth()).isGreaterThan(0);
+        assertThat(image.getHeight()).isGreaterThan(0);
+    }
+
+    @SneakyThrows
+    @Test
+    void test_generate_image_with_computedTransitions_and_styles() {
+        // given
+        GraphvizImageGenerator generator = builder.computedTransitions(computedTransitions).build();
+        // when
+        assertThat(generator).isNotNull();
+        String strPath = "image/my-workflow-from-test-computed-transitions.png";
+        generator.generateImage(transitions,
+                strPath,
+                Format.PNG,
+                StyleGraph.SKETCHY,
+                Orientation.HORIZONTAL);
+        // then
+        Path path = Paths.get(strPath);
+        assertThat(Files.exists(path)).isTrue(); // custom output path
+    }
+
+    @SneakyThrows
+    @Test
+    void test_generate_image_with_computedTransitions_and_styles_and_format_SVG() {
+        // given
+        GraphvizImageGenerator generator = builder.computedTransitions(computedTransitions).build();
+        // when
+        assertThat(generator).isNotNull();
+        String strPath = "image/my-workflow-from-test-computed-transitions.svg";
+        generator.generateImage(transitions,
+                strPath,
+                Format.SVG,
+                Orientation.VERTICAL);
+        // then
+        Path path = Paths.get(strPath);
+        assertThat(Files.exists(path)).isTrue(); // custom output path
+    }
+
+    @SneakyThrows
+    @Test
+    void test_generate_image_with_computedTransitions_and_styles_and_dotFormat() {
+        // given
+        GraphvizImageGenerator generator = builder
+                .computedTransitions(computedTransitions) // will be ignored when dotFormat is provided
+                .dotFormat("digraph { _start_ -> a -> b -> c -> d -> _end_; }")
+                .build();
+        // when
+        assertThat(generator).isNotNull();
+        String strPath = "image/my-workflow-from-test-dot-computed-transitions.svg";
+        generator.generateImage(null,
+                strPath,
+                Format.SVG,
+                StyleGraph.SKETCHY,
+                Orientation.HORIZONTAL);
+        // then
+        Path path = Paths.get(strPath);
+        assertThat(Files.exists(path)).isTrue(); // custom output path
+    }
+
+    @SneakyThrows
+    @Test
+    void test_buffered_image_with_computedTransitions_and_styles() {
+        // given
+        GraphvizImageGenerator generator = builder.computedTransitions(computedTransitions).build();
+        // when
+        assertThat(generator).isNotNull();
+        BufferedImage image = generator.generateBufferedImage(transitions,
+                Format.SVG,
+                StyleGraph.SKETCHY,
+                Orientation.HORIZONTAL);
+        // then
+        assertThat(image).isNotNull();
+        assertThat(image.getType()).isEqualTo(BufferedImage.TYPE_INT_ARGB);
+        assertThat(image.getWidth()).isGreaterThan(0);
+        assertThat(image.getHeight()).isGreaterThan(0);
+    }
+
+    @SneakyThrows
+    @Test
+    void test_buffered_image_with_computedTransitions_and_styles_and_format_PNG() {
+        // given
+        GraphvizImageGenerator generator = builder.computedTransitions(computedTransitions).build();
+        // when
+        assertThat(generator).isNotNull();
+        BufferedImage image = generator.generateBufferedImage(transitions,
+                Format.PNG,
+                Orientation.VERTICAL);
+        // then
+        assertThat(image).isNotNull();
+        assertThat(image.getType()).isEqualTo(BufferedImage.TYPE_INT_ARGB);
+        assertThat(image.getWidth()).isGreaterThan(0);
+        assertThat(image.getHeight()).isGreaterThan(0);
     }
 }

--- a/jai-workflow-core/src/test/java/io/github/czelabueno/jai/workflow/node/ConditionalTest.java
+++ b/jai-workflow-core/src/test/java/io/github/czelabueno/jai/workflow/node/ConditionalTest.java
@@ -1,67 +1,193 @@
 package io.github.czelabueno.jai.workflow.node;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
 import java.util.function.Function;
 
 import static org.assertj.core.api.Assertions.*;
 
 class ConditionalTest {
 
+    // validated
+    Node<Integer, String> node1;
+    Node<Integer, String> node2;
+
+    @BeforeEach
+    void setUp() {
+        Function<Integer, String> sumToString = num -> {
+            num += 1;
+            return num.toString();
+        };
+        Function<Integer, String> subsToString = num -> {
+            num -= 1;
+            return num.toString();
+        };
+        node1 = Node.from("node1", sumToString);
+        node2 = Node.from("node2", subsToString);
+    }
     @Test
     void test_validate_constructor() {
-        Function<String, Node> condition = s -> Node.from(s, (String s1) -> s1 + "1");
-        Conditional conditional = new Conditional(condition);
+        Function<String, Node> condition = s -> s.equals("sum") ? node1 : node2;
+        Conditional conditional = new Conditional("condition", condition, List.of(node1,node2));
         assertThat(conditional).isNotNull();
     }
 
     @Test
     void test_null_condition_constructor() {
+        // Condition null
         assertThatExceptionOfType(NullPointerException.class)
-                .isThrownBy(() -> new Conditional(null))
+                .isThrownBy(() -> new Conditional("condition", null, List.of(node1)))
                 .withMessage("Condition function cannot be null");
+        // Expected nodes null
+        assertThatExceptionOfType(NullPointerException.class)
+                .isThrownBy(() -> new Conditional("condition", s -> s, null))
+                .withMessage("The list of nodes expected from the condition function cannot be null");
+    }
+
+    @Test
+    void test_empty_expected_nodes_constructor() {
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> new Conditional("condition", s -> s, List.of()))
+                .withMessage("The list of nodes expected from the condition function cannot be empty");
     }
 
     @Test
     void test_evaluate_valid_input() {
-        Function<String, Node> condition = (String s) -> {
-            if (s.equals("test")) {
-                return Node.from("node1", (String s1) -> s1 + "1");
-            }
-            return null;
-        };
-        Conditional conditional = new Conditional(condition);
-        Node node = conditional.evaluate("test");
+        // given
+        Function<String, Node> condition = s -> s.equals("sum") ? node1 : node2;
+
+        // when
+        Conditional conditional = new Conditional("condition", condition, List.of(node1, node2));
+        Node node = conditional.evaluate("sum");
+
+        // then
         assertThat(node).isNotNull();
+        assertThat(node).isEqualTo(node1);
         assertThat(node.getName()).isEqualTo("node1");
 
-        Node nullNode = conditional.evaluate("other");
-        assertThat(nullNode).isNull();
+        // when
+        Node other = conditional.evaluate("other");
+
+        // then
+        assertThat(other).isNotNull();
+        assertThat(other).isEqualTo(node2);
+        assertThat(other.getName()).isEqualTo("node2");
     }
 
     @Test
     void test_evaluate_null_input() {
-        Function<String, Node> condition = s -> Node.from(s, (String s1) -> s1 + "1");
-        Conditional conditional = new Conditional(condition);
+        Function<String, Node> condition = s -> s.equals("subs") ? node2 : node1;
+
+        Conditional conditional = new Conditional("condition", condition, List.of(node2, node1));
         assertThatExceptionOfType(NullPointerException.class)
                 .isThrownBy(() -> conditional.evaluate(null))
                 .withMessage("Function Input cannot be null");
     }
 
     @Test
-    void test_eval_static_method() {
-        Function<String, Node<String, ?>> condition = s -> Node.from(s, (String s1) -> s1 + "1");
-        Conditional<String> conditional = Conditional.eval(condition);
-        assertThat(conditional).isNotNull();
+    void test_inline_eval_static_method() {
+        // given
+        Node nodeReturned = Conditional.eval(
+                "condition",
+                s -> s > 5 ? node2 : node1, // function input type expected is the same node input type
+                List.of(node2, node1)
+        ).evaluate(6);
+
+        // then
+        assertThat(nodeReturned).isNotNull();
+        assertThat(nodeReturned).isEqualTo(node2);
+        assertThat(nodeReturned.getName()).isEqualTo("node2");
+    }
+
+    @Test
+    void test_ignore_generic_type_in_eval_static_method() {
+        // given
+        Function condition = s -> s.equals("subs") ? node2 : node1; // function without generic type
+
+        Conditional conditional = Conditional.eval("condition",
+                condition,
+                List.of(node2, node1));
+        Node node = conditional.evaluate("sum");
+
+        // then
+        assertThat(node).isNotNull();
+        assertThat(node).isEqualTo(node1);
+        assertThat(node.getName()).isEqualTo("node1");
+
+        // when
+        Node other = conditional.evaluate("subs");
+
+        // then
+        assertThat(other).isNotNull();
+        assertThat(other).isEqualTo(node2);
+        assertThat(other.getName()).isEqualTo("node2");
+    }
+
+    @Test
+    void test_any_expected_nodes_does_not_match_with_returned_node() {
+        assertThatExceptionOfType(RuntimeException.class)
+                .isThrownBy(() -> Conditional.eval(
+                        "condition",
+                        s -> s > 5 ? node2 : node1,
+                        List.of(node1) // node2 is expected
+                        )
+                        .evaluate(6))
+                .withMessageStartingWith("The condition function returned an invalid node type")
+                .withMessageContaining("node1")
+                .withMessageEndingWith("but got: node2 instead.");
+    }
+
+    @Test
+    void test_conditional_get_graph_name() {
+        Function<String, Node> condition = s -> node1;
+        Conditional conditional = new Conditional("CONDITION", condition, List.of(node1));
+        assertThat(conditional.graphName()).isEqualTo("condition"); // lower case expected
+    }
+
+    @Test
+    void test_conditional_has_labels() {
+        Function<String, Node> condition = s -> node1;
+        Conditional conditional = new Conditional("condition", condition, List.of(node1));
+        assertThat(conditional.hasLabel("label")).isFalse();
+        assertThat(conditional.hasLabel("Conditional")).isTrue();
+        assertThat(conditional.labels()).anySatisfy(label -> assertThat(label).isEqualTo("Conditional"));
+    }
+
+    @Test
+    void test_conditional_input_and_output_values() {
+        Function<String, Node> condition = s -> node1;
+        Conditional conditional = new Conditional("condition", condition, List.of(node1));
+        assertThat(conditional.input()).isNull(); // null because the .evaluate() method is not called
+        assertThat(conditional.output()).isNull();
+
+        conditional.evaluate("input");
+        assertThat(conditional.input()).isEqualTo("input");
+        assertThat(conditional.output()).isEqualTo(node1.getName()); // output value contains the node name only
+    }
+
+    @Test
+    void test_conditional_input_and_output_types_and_values() {
+        Function<Integer, Node> condition = s -> s > 5 ? node2 : node1;
+        Conditional conditional = new Conditional("condition", condition, List.of(node1, node2));
+        conditional.evaluate(6);
+
+        // Check input type and value
+        assertThat(conditional.input()).isInstanceOf(Integer.class);
+        assertThat(conditional.input()).isEqualTo(6);
+        // Check output type and value
+        assertThat(conditional.output()).isInstanceOf(String.class);
+        assertThat(conditional.output()).isEqualTo(node2.getName());
     }
 
     @Test
     void test_equals_and_hash() {
-        Function<String, Node> condition1 = s -> Node.from(s, (String s1) -> s1 + "1");
-        Function<String, Node> condition2 = s -> Node.from(s, (String s1) -> s1 + "2");
-        Conditional conditional1 = new Conditional(condition1);
-        Conditional conditional2 = new Conditional(condition1);
-        Conditional conditional3 = new Conditional(condition2);
+        Function<String, Node> condition1 = s -> node1;
+        Function<String, Node> condition2 = s -> node2;
+        Conditional conditional1 = new Conditional("condition", condition1, List.of(node1));
+        Conditional conditional2 = new Conditional("condition", condition1, List.of(node1));
+        Conditional conditional3 = new Conditional("condition2", condition2, List.of(node2));
         assertThat(conditional1)
                 .isEqualTo(conditional1)
                 .isNotEqualTo(null)
@@ -73,8 +199,8 @@ class ConditionalTest {
 
     @Test
     void test_toString() {
-        Function<String, Node> condition = s -> Node.from(s, (String s1) -> s1 + "1");
-        Conditional conditional = new Conditional(condition);
-        assertThat(conditional.toString()).isEqualTo("Conditional{condition=" + condition + "}");
+        Function<String, Node> condition = s -> node1;
+        Conditional conditional = new Conditional("condition", condition, List.of(node1));
+        assertThat(conditional.toString()).isEqualTo("Conditional{name='condition, condition=" + condition + ", validNodes=" + List.of(node1) + "}");
     }
 }

--- a/jai-workflow-core/src/test/java/io/github/czelabueno/jai/workflow/node/NodeTest.java
+++ b/jai-workflow-core/src/test/java/io/github/czelabueno/jai/workflow/node/NodeTest.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class NodeTest {
 
+    // validated
     @Test
     void test_valid_constructor() {
         Node node = Node.from("node1", (String s) -> s + "1");
@@ -38,7 +39,7 @@ class NodeTest {
         Node node = Node.from("node1", (String s) -> s + "1");
         assertThat(node.getName()).isEqualTo("node1");
         assertThat(node.execute("test")).isEqualTo("test1");
-        assertThat(node.getFunctionInput()).isEqualTo("test");
+        assertThat(node.input()).isEqualTo("test");
     }
 
     @Test
@@ -49,8 +50,8 @@ class NodeTest {
         };
         Node node = Node.from("node1", sumToString);
         assertThat(node.execute(1)).isEqualTo("2");
-        assertThat(node.getFunctionInput()).isEqualTo(1);
-        assertThat(node.getFunctionOutput()).isEqualTo("2");
+        assertThat(node.input()).isEqualTo(1);
+        assertThat(node.output()).isEqualTo("2");
     }
 
     @Test
@@ -58,6 +59,53 @@ class NodeTest {
         Node node = Node.from("node1", (String s) -> s + "1");
         IllegalArgumentException ilegal = assertThrows(IllegalArgumentException.class, () -> node.execute(null));
         assertThat(ilegal.getMessage()).isEqualTo("Function input cannot be null");
+    }
+
+    @Test
+    void test_node_get_name() {
+        Node node = Node.from("node1", (String s) -> s + "1");
+        assertThat(node.getName()).isEqualTo("node1");
+    }
+
+    @Test
+    void test_node_get_graph_name() {
+        Node node = Node.from("NODE1", (String s) -> s + "1");
+        assertThat(node.graphName()).isEqualTo("node1"); // graph name is lower case
+    }
+
+    @Test
+    void test_node_has_label() {
+        Node node = Node.from("node1", (String s) -> s + "1");
+        assertThat(node.hasLabel("label")).isFalse();
+
+        node.setLabels("label");
+        assertThat(node.hasLabel("label")).isTrue();
+        assertThat(node.getLabel("label")).isEqualTo("label");
+    }
+
+    @Test
+    void test_node_function_input_and_output_values() {
+        Node<String, String> node = Node.from("node1", s -> s + "1");
+        node.execute("test");
+        assertThat(node.input()).isEqualTo("test");
+        assertThat(node.output()).isEqualTo("test1");
+    }
+
+    @Test
+    void test_node_function_input_and_output_types_and_values() {
+        Function<Integer, String> sumToString = num -> {
+            num += 1;
+            return num.toString();
+        };
+        Node<Integer, String> node = Node.from("node1", sumToString);
+        node.execute(1);
+
+        // Check input type and value
+        assertThat(node.input()).isInstanceOf(Integer.class);
+        assertThat(node.input()).isEqualTo(1);
+        // Check output type and value
+        assertThat(node.output()).isInstanceOf(String.class);
+        assertThat(node.output()).isEqualTo("2");
     }
 
     @Test

--- a/jai-workflow-core/src/test/java/io/github/czelabueno/jai/workflow/transition/ComputedTransitionTest.java
+++ b/jai-workflow-core/src/test/java/io/github/czelabueno/jai/workflow/transition/ComputedTransitionTest.java
@@ -1,0 +1,160 @@
+package io.github.czelabueno.jai.workflow.transition;
+
+import io.github.czelabueno.jai.workflow.node.Node;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class ComputedTransitionTest {
+
+    // validated
+    @Test
+    void should_build_computed_transition_using_from() {
+        // given
+        // node mocked to simulate that the transition was computed
+        Node mockFromNode = mock(Node.class);
+        Node mockToNode = mock(Node.class);
+        when(mockFromNode.output()).thenReturn("mockedPayloadOfFromNode");
+        when(mockFromNode.graphName()).thenReturn("from");
+        when(mockToNode.graphName()).thenReturn("to");
+
+        ComputedTransition computedTransition = ComputedTransition.from(
+                1,
+                Transition.from(mockFromNode, mockToNode)
+        );
+
+        // then
+        assertThat(computedTransition.getId()).isNotNull();
+        assertThat(computedTransition.getOrder()).isEqualTo(1);
+        assertThat(computedTransition.getTransition().from().graphName()).isEqualTo("from");
+        assertThat(computedTransition.getTransition().to().graphName()).isEqualTo("to");
+        assertThat(computedTransition.getComputedAt()).isBefore(LocalDateTime.now());
+        assertThat(computedTransition.getPayload()).isEqualTo("mockedPayloadOfFromNode");
+    }
+
+    @Test
+    void should_throw_exception_when_build_order_arg_is_null() {
+        // then
+        assertThatExceptionOfType(NullPointerException.class)
+                .isThrownBy(() -> ComputedTransition.from(
+                        null,
+                        null
+                ))
+                .withMessage("order is marked non-null but is null");
+    }
+
+    @Test
+    void should_throw_exception_when_build_transition_arg_is_null() {
+        // then
+        assertThatExceptionOfType(NullPointerException.class)
+                .isThrownBy(() -> ComputedTransition.from(
+                        1,
+                        null
+                ))
+                .withMessage("transition is marked non-null but is null");
+    }
+
+    @Test
+    void should_throw_exception_when_transition_from_is_null() {
+        // given
+        Transition mockTransition = mock(Transition.class);
+        when(mockTransition.from()).thenReturn(null);
+
+        // then
+        assertThatExceptionOfType(RuntimeException.class)
+                .isThrownBy(() -> ComputedTransition.from(
+                        1,
+                        mockTransition
+                ))
+                .withMessage("Transition node 'from' cannot be null");
+    }
+
+    @Test
+    void should_throw_exception_when_transition_to_is_null() {
+        // given
+        Node mockFromNode = mock(Node.class);
+        Transition mockTransition = mock(Transition.class);
+        when(mockTransition.from()).thenReturn(mockFromNode);
+        when(mockTransition.to()).thenReturn(null);
+
+        // then
+        assertThatExceptionOfType(RuntimeException.class)
+                .isThrownBy(() -> ComputedTransition.from(
+                        1,
+                        mockTransition
+                ))
+                .withMessage("Transition node 'to' cannot be null");
+    }
+
+    @Test
+    void should_throw_exception_when_transition_order_is_negative() {
+        // given
+        Node mockFromNode = mock(Node.class);
+        Node mockToNode = mock(Node.class);
+        Transition mockTransition = mock(Transition.class);
+        when(mockTransition.from()).thenReturn(mockFromNode);
+        when(mockTransition.to()).thenReturn(mockToNode);
+
+        // then
+        assertThatExceptionOfType(RuntimeException.class)
+                .isThrownBy(() -> ComputedTransition.from(
+                        -1,
+                        mockTransition
+                ))
+                .withMessage("Transition order cannot be negative");
+    }
+
+    @Test
+    void should_throw_exception_when_transition_order_is_zero() {
+        // given
+        Node mockFromNode = mock(Node.class);
+        Node mockToNode = mock(Node.class);
+        Transition mockTransition = mock(Transition.class);
+        when(mockTransition.from()).thenReturn(mockFromNode);
+        when(mockTransition.to()).thenReturn(mockToNode);
+
+        // then
+        assertThatExceptionOfType(RuntimeException.class)
+                .isThrownBy(() -> ComputedTransition.from(
+                        0,
+                        mockTransition
+                ))
+                .withMessage("Transition order cannot be negative");
+    }
+
+    @Test
+    void test_equals_and_hash() {
+        // given
+        Node mockFromNode = mock(Node.class);
+        Node mockToNode = mock(Node.class);
+        Transition transition = Transition.from(mockFromNode, mockToNode);
+        ComputedTransition computedTransition1 = ComputedTransition.from(1, transition);
+        ComputedTransition computedTransition2 = ComputedTransition.from(1, transition);
+
+        // then
+        // Each instance has a different id. They can never be the same.
+        assertThat(computedTransition1)
+                .isEqualTo(computedTransition1)
+                .isNotEqualTo(null)
+                .isNotEqualTo(new Object())
+                .isNotEqualTo(computedTransition2)
+                .doesNotHaveSameHashCodeAs(computedTransition2);
+    }
+
+    @Test
+    void test_toString() {
+        // given
+        Node mockFromNode = mock(Node.class);
+        Node mockToNode = mock(Node.class);
+        Transition transition = Transition.from(mockFromNode, mockToNode);
+        ComputedTransition computedTransition = ComputedTransition.from(1, transition);
+
+        // then
+        assertThat(computedTransition.toString()).isEqualTo("ComputedTransition{id=" + computedTransition.getId() + ", order=1, transition=" + transition + ", computedAt=" + computedTransition.getComputedAt() + ", payload=" + computedTransition.getPayload() + "}");
+    }
+}

--- a/jai-workflow-core/src/test/java/io/github/czelabueno/jai/workflow/transition/TransitionTest.java
+++ b/jai-workflow-core/src/test/java/io/github/czelabueno/jai/workflow/transition/TransitionTest.java
@@ -9,6 +9,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 class TransitionTest {
 
+    // validated
     @Test
     void should_build_transition_using_from() {
         Transition transition = Transition.from(
@@ -47,7 +48,7 @@ class TransitionTest {
         assertThat(transition.from()).isEqualTo(from);
         assertThat(transition.to()).isEqualTo(to);
 
-        assertThat(transition).hasToString("node1 -> END");
+        assertThat(transition).hasToString("node1 -> _end_");
     }
     // Transition WorkflowState to Node
     @Test
@@ -61,7 +62,7 @@ class TransitionTest {
         assertThat(transition.from()).isEqualTo(from);
         assertThat(transition.to()).isEqualTo(to);
 
-        assertThat(transition).hasToString("START -> node2");
+        assertThat(transition).hasToString("_start_ -> node2");
     }
 
     @Test

--- a/jai-workflow-core/src/test/resources/tinylog.properties
+++ b/jai-workflow-core/src/test/resources/tinylog.properties
@@ -1,0 +1,1 @@
+writer.level = debug

--- a/jai-workflow-langchain4j/pom.xml
+++ b/jai-workflow-langchain4j/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.github.czelabueno</groupId>
         <artifactId>jai-workflow-parent</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/jai-workflow-langchain4j/pom.xml
+++ b/jai-workflow-langchain4j/pom.xml
@@ -85,5 +85,17 @@
             <version>${langchain4j.version}</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.tinylog</groupId>
+            <artifactId>tinylog-impl</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.tinylog</groupId>
+            <artifactId>slf4j-tinylog</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/jai-workflow-langchain4j/src/main/java/io/github/czelabueno/jai/workflow/langchain4j/JAiWorkflow.java
+++ b/jai-workflow-langchain4j/src/main/java/io/github/czelabueno/jai/workflow/langchain4j/JAiWorkflow.java
@@ -2,7 +2,12 @@ package io.github.czelabueno.jai.workflow.langchain4j;
 
 import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.UserMessage;
+import io.github.czelabueno.jai.workflow.StateWorkflow;
 import reactor.core.publisher.Flux;
+
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+import java.nio.file.Path;
 
 import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 
@@ -10,7 +15,7 @@ import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
  * The {@link JAiWorkflow} interface defines the entry-point contract for a workflow that processes user messages
  * and generates AI responses. It provides basic methods for synchronous and asynchronous (streaming) responses.
  */
-public interface JAiWorkflow {
+public interface JAiWorkflow extends StateWorkflow {
 
     /**
      * Generates an AI response to the given question.
@@ -53,4 +58,22 @@ public interface JAiWorkflow {
      * @return a Flux stream of the AI response tokens
      */
     Flux<String> answerStream(UserMessage question);
+
+    /**
+     * Generates a workflow image of the current workflow state.
+     * This method ensures that the workflow image output path is not null before processing.
+     *
+     * @param workflowImageOutputPath the path to save the workflow image
+     * @return the workflow image as a {@link JAiWorkflow}
+     * @throws IOException if an I/O error occurs
+     * @throws IllegalArgumentException if the workflow image output path is null
+     */
+    JAiWorkflow getWorkflowImage(Path workflowImageOutputPath) throws IOException;
+
+    /**
+     * Gets the workflow image as a {@link BufferedImage}.
+     *
+     * @return the workflow image as a {@link BufferedImage}
+     */
+    BufferedImage getWorkflowImage();
 }

--- a/jai-workflow-langchain4j/src/main/java/io/github/czelabueno/jai/workflow/langchain4j/node/StreamingNode.java
+++ b/jai-workflow-langchain4j/src/main/java/io/github/czelabueno/jai/workflow/langchain4j/node/StreamingNode.java
@@ -116,7 +116,7 @@ public class StreamingNode<T extends AbstractStatefulBean> extends Node<T, Flux<
     private static <T extends AbstractStatefulBean> Flux<String> streamingFunction(
             T statefulBean,
             List<ChatMessage> messages,
-            Function<T, ChatMessage> doUserMessage,
+            Function<T, ChatMessage> doUserMessage, //TODO: Function could return a list of ChatMessage
             StreamingChatLanguageModel streamingChatLanguageModel) {
         Sinks.Many<String> sink = Sinks.many().unicast().onBackpressureBuffer();
         CompletableFuture<AiMessage> futureResponse = new CompletableFuture<>();

--- a/jai-workflow-langchain4j/src/test/resources/tinylog.properties
+++ b/jai-workflow-langchain4j/src/test/resources/tinylog.properties
@@ -1,0 +1,1 @@
+writer.level = debug

--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,12 @@
       </dependency>
 
       <dependency>
+        <groupId>guru.nidi</groupId>
+        <artifactId>graphviz-rough</artifactId>
+        <version>${graphviz-java.version}</version>
+      </dependency>
+
+      <dependency>
         <groupId>org.graalvm.js</groupId>
         <artifactId>js</artifactId>
         <version>${graal.js.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>io.github.czelabueno</groupId>
   <artifactId>jai-workflow-parent</artifactId>
-  <version>0.2.0-SNAPSHOT</version>
+  <version>0.3.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>JavAI Workflow</name>


### PR DESCRIPTION
This PR introduce basis to implement multiple flow patterns for workflow orchestration.

### **Features:**
####  Workflow Lifecycle
- New _definition_ parameters
  ```java
  var myWorkflowDef = DefaultStateWorkflow.<~>builder()
                .statefulBean(myStatefulBean)
                .addEdges(Transition....);
  ```
- New _build_ parameters
  ```java
  var myworkflow = DefaultStateWorkflow.<~>builder()
              .statefulBean(myStatefulBean)
              .addEdges(Transition....)
              .build(startNode); // build parameters
  ```
- New _run_ parameters
  - `myworkflow.run()` synchronous workflow execution
  - `myworkflow.runStream(Consumer<Node>)` streaming workflow execution
  - `ComputedTransition` - Get _state logs_
     ```java
     myworkflow.run();
     List<ComputedTransition> tx = myWorkflow.getComputedTransitions();
     // print
     //[node2 -> node3 {Order: 1, ComputedAt: 2025-03-11T01:08:05.839200, Payload: Node2: function proceed }]
     //[node3 -> greater than 6? {Order: 2, ComputedAt: 2025-03-11T01:08:05.839255, Payload: Node3: function proceed }]
    //[greater than 6? -> node4 {Order: 3, ComputedAt: 2025-03-11T01:08:05.839294, Payload: node4 }]
    //[node4 -> _end_ {Order: 4, ComputedAt: 2025-03-11T01:08:05.839353, Payload: Node4: function proceed }]
     ``` 

#### Workflow states
- `TransitionState`:  added ‘labels’.
- `Node`: Parallel Node (labeled)
- `Node`: Split Node (labeled)
- `Node`: Merge Node (labeled)
- `Conditional` Node: added ‘expectedNodes’ build parameter.
  ```java
  Conditional conditional = new Conditional(
              "condition", 
              s -> s.equals("subs") ? node2 : node1;, 
              List.of(node2, node1) // expected nodes
  );
  ```
#### Workflow modification state after build.
- `myworkflow.putEdge(TransitionState from, TransitionState to)`
- `myworkflow.startNode(Node)`
- `myworkflow.addNode(Node)`
```java
myworkflow.putEdge(node3, node4);
myworkflow.startNode(node2);
myworkflow.run();
```

#### Workflow image generation
- Graph: Image generated, new default style (pre & post run)
   ```java
   // pre-run
   myworkflow.generateWorkflowImage(imagePath, List.of(Orientation.HORIZONTAL));
   // post-run
   myworkflow.generateComputedWorkflowImage(imagePath, List.of(Orientation.HORIZONTAL));
   ```
- Graph: support new image format `Format.PNG`.
   ```java
    myworkflow.generateWorkflowImage(Format.PNG, imagePath);
   ```
- Graph: in-line image generation (`BufferedImage` type)
   ```java
   // pre-run
   BufferedImage image = myWorkflow.generateWorkflowBufferedImage();
   // post-run
   BufferedImage image = myworkflow.generateComputedWorkflowBufferedImage();
   ```
- Graphviz Implementation:
   - Sketchy style: `StyleGraph.SKETCHY`
   - Graph Orientation: `Orientation.HORIZONTAL` and `Orientation.VERTICAL`
   - Builder params support: `String` dotFormat and `List<ComputedTransition>`

### **Issues related:**
Closes #14
Closes #19 

### **Graph Image generation:**
- Workflow definition image (pre)
![definition-branching-jai-workflow](https://github.com/user-attachments/assets/1b52da84-eaf3-4d21-846c-fa91022c9c51)
- Workflow computed image (post)
![definition-computed-branching-jai-workflow](https://github.com/user-attachments/assets/6d6bebf6-3a59-44a5-81a4-8b26c5cfa1d0)

- Workflow Sketchy style
![definition-branching-jai-workflow-beauty](https://github.com/user-attachments/assets/561e614f-80ae-435a-a7d7-32ebbdcfc22c)

